### PR TITLE
Document LinkedIn OAuth state validation in OpenAPI spec

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -56,6 +56,7 @@ paths:
   /auth/linkedin/callback:
     get:
       summary: Callback OAuth LinkedIn
+      description: Vérifie côté serveur la correspondance du couple code/state renvoyé par LinkedIn avant d'établir la session utilisateur.
       tags: [Authentication]
       parameters:
         - name: code
@@ -63,6 +64,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: state
+          in: query
+          required: true
+          description: Jeton anti-CSRF généré côté serveur et renvoyé par LinkedIn pour valider la requête.
+          schema:
+            type: string
+            example: 1a2b3c4d5e
       responses:
         '200':
           description: Authentification réussie
@@ -75,6 +83,12 @@ paths:
                     type: string
                   user:
                     $ref: '#/components/schemas/User'
+        '400':
+          description: Paramètre state manquant ou invalide
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /profiles:
     get:
@@ -355,3 +369,16 @@ components:
         timestamp:
           type: string
           format: date-time
+
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          description: Code d'erreur machine interprétable.
+          example: INVALID_STATE
+        message:
+          type: string
+          description: Description lisible du problème rencontré.
+          example: Le paramètre state est manquant ou invalide.


### PR DESCRIPTION
## Summary
- add required LinkedIn OAuth state query parameter with details
- document 400 error when the state token is missing or invalid
- introduce reusable error response schema for authentication errors

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d78a1b2bf08332abf2f02446deec92