### PR TITLE
Add pagination parameters and metadata to listing endpoints

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -78,24 +78,31 @@ paths:
 
   /profiles:
     get:
-      summary: Obtenir les profils pour le swipe
+      summary: Obtenir les profils paginés pour le swipe
+      description: Permet de récupérer une liste paginée de profils à parcourir avec support du décalage et d'une limite configurable.
       tags: [Profiles]
       security:
         - bearerAuth: []
       parameters:
         - name: limit
           in: query
+          description: Nombre maximum de profils à retourner par page.
           schema:
             type: integer
             default: 10
+            minimum: 1
+            maximum: 50
         - name: offset
           in: query
+          description: Décalage de pagination indiquant le nombre de profils à ignorer.
           schema:
             type: integer
             default: 0
+            minimum: 0
+            maximum: 500
       responses:
         '200':
-          description: Liste des profils
+          description: Liste des profils avec métadonnées de pagination
           content:
             application/json:
               schema:
@@ -107,10 +114,16 @@ paths:
                       $ref: '#/components/schemas/Profile'
                   total:
                     type: integer
+                  has_more:
+                    type: boolean
+                  next_offset:
+                    type: integer
+                required: [profiles, total, has_more]
 
   /events:
     get:
-      summary: Obtenir les événements
+      summary: Obtenir les événements paginés
+      description: Retourne une liste paginée d'événements filtrables par catégorie ou recherche, avec contrôle du nombre d'éléments et du décalage.
       tags: [Events]
       security:
         - bearerAuth: []
@@ -125,12 +138,23 @@ paths:
             type: string
         - name: limit
           in: query
+          description: Nombre maximum d'événements à retourner par page.
           schema:
             type: integer
             default: 20
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          description: Décalage de pagination indiquant le nombre d'événements à ignorer.
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+            maximum: 1000
       responses:
         '200':
-          description: Liste des événements
+          description: Liste des événements avec métadonnées de pagination
           content:
             application/json:
               schema:
@@ -142,6 +166,11 @@ paths:
                       $ref: '#/components/schemas/Event'
                   total:
                     type: integer
+                  has_more:
+                    type: boolean
+                  next_offset:
+                    type: integer
+                required: [events, total, has_more]
 
   /events/{id}/join:
     post:


### PR DESCRIPTION
## Summary
- document paginated access for profile listings with enriched metadata
- describe paginated event retrieval including limit and offset controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d78a209b888332894c39ba414b404a