### PR TITLE
Add infrastructure provisioning and operations stack

### DIFF
--- a/infra/helm/README.md
+++ b/infra/helm/README.md
@@ -1,0 +1,30 @@
+# Meetinity Helm Charts
+
+This directory contains self-contained Helm charts for Meetinity microservices.
+
+## Charts
+
+- `api-gateway`
+- `user-service`
+- `matching-service`
+- `event-service`
+
+Each chart expects the following values when installed:
+
+- `environment`: deployment stage (dev, staging, prod). Used to build ingress hostnames.
+- `domain`: top-level domain appended to ingress hosts.
+- `image.repository` / `image.tag`: container image configuration.
+- `env`: list of environment variables propagated to the workload.
+
+## Usage
+
+Deploy a chart with:
+
+```bash
+helm upgrade --install api-gateway infra/helm/api-gateway \
+  --namespace default \
+  --set environment=dev \
+  --set domain=meetinity.com
+```
+
+Override `values.yaml` as necessary for production (e.g. resource limits, ingress annotations).

--- a/infra/helm/api-gateway/Chart.yaml
+++ b/infra/helm/api-gateway/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: api-gateway
+description: Deploys the Meetinity API Gateway service.
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infra/helm/api-gateway/templates/_helpers.tpl
+++ b/infra/helm/api-gateway/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{- define "api-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "api-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "api-gateway.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "api-gateway.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "api-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "api-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "api-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "api-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- include "api-gateway.fullname" . -}}
+{{- end -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/infra/helm/api-gateway/templates/deployment.yaml
+++ b/infra/helm/api-gateway/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "api-gateway.fullname" . }}
+  labels:
+    {{- include "api-gateway.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "api-gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "api-gateway.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "api-gateway.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}

--- a/infra/helm/api-gateway/templates/hpa.yaml
+++ b/infra/helm/api-gateway/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "api-gateway.fullname" . }}
+  labels:
+    {{- include "api-gateway.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "api-gateway.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/api-gateway/templates/ingress.yaml
+++ b/infra/helm/api-gateway/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "api-gateway.fullname" . }}
+  labels:
+    {{- include "api-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ printf "%s.%s.%s" .Values.ingress.subdomain .Values.environment .Values.domain }}
+      http:
+        paths:
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "api-gateway.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+  {{- if .Values.ingress.tlsSecretName }}
+  tls:
+    - secretName: {{ .Values.ingress.tlsSecretName }}
+      hosts:
+        - {{ printf "%s.%s.%s" .Values.ingress.subdomain .Values.environment .Values.domain }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/api-gateway/templates/service.yaml
+++ b/infra/helm/api-gateway/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "api-gateway.fullname" . }}
+  labels:
+    {{- include "api-gateway.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "api-gateway.selectorLabels" . | nindent 4 }}

--- a/infra/helm/api-gateway/templates/serviceaccount.yaml
+++ b/infra/helm/api-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "api-gateway.serviceAccountName" . }}
+  labels:
+    {{- include "api-gateway.labels" . | nindent 4 }}
+{{- end }}

--- a/infra/helm/api-gateway/values.yaml
+++ b/infra/helm/api-gateway/values.yaml
@@ -1,0 +1,56 @@
+environment: dev
+domain: meetinity.com
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/meetinity/api-gateway
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: ""
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  subdomain: api
+  tlsSecretName: api-gateway-tls
+  paths:
+    - path: /
+      pathType: Prefix
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+env:
+  - name: FLASK_ENV
+    value: production
+  - name: LOG_LEVEL
+    value: info
+
+livenessProbe:
+  path: /healthz
+  port: http
+
+readinessProbe:
+  path: /ready
+  port: http

--- a/infra/helm/event-service/Chart.yaml
+++ b/infra/helm/event-service/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: event-service
+description: Deploys the Meetinity Event Service API.
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infra/helm/event-service/templates/_helpers.tpl
+++ b/infra/helm/event-service/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{- define "event-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "event-service.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "event-service.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "event-service.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "event-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "event-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "event-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "event-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- include "event-service.fullname" . -}}
+{{- end -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/infra/helm/event-service/templates/deployment.yaml
+++ b/infra/helm/event-service/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "event-service.fullname" . }}
+  labels:
+    {{- include "event-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "event-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "event-service.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "event-service.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}

--- a/infra/helm/event-service/templates/hpa.yaml
+++ b/infra/helm/event-service/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "event-service.fullname" . }}
+  labels:
+    {{- include "event-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "event-service.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/event-service/templates/ingress.yaml
+++ b/infra/helm/event-service/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "event-service.fullname" . }}
+  labels:
+    {{- include "event-service.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ printf "%s.%s.%s" .Values.ingress.subdomain .Values.environment .Values.domain }}
+      http:
+        paths:
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "event-service.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+  {{- if .Values.ingress.tlsSecretName }}
+  tls:
+    - secretName: {{ .Values.ingress.tlsSecretName }}
+      hosts:
+        - {{ printf "%s.%s.%s" .Values.ingress.subdomain .Values.environment .Values.domain }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/event-service/templates/service.yaml
+++ b/infra/helm/event-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "event-service.fullname" . }}
+  labels:
+    {{- include "event-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "event-service.selectorLabels" . | nindent 4 }}

--- a/infra/helm/event-service/templates/serviceaccount.yaml
+++ b/infra/helm/event-service/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "event-service.serviceAccountName" . }}
+  labels:
+    {{- include "event-service.labels" . | nindent 4 }}
+{{- end }}

--- a/infra/helm/event-service/values.yaml
+++ b/infra/helm/event-service/values.yaml
@@ -1,0 +1,56 @@
+environment: dev
+domain: meetinity.com
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/meetinity/event-service
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: ""
+
+service:
+  type: ClusterIP
+  port: 5002
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  subdomain: events
+  tlsSecretName: event-service-tls
+  paths:
+    - path: /
+      pathType: Prefix
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 65
+  targetMemoryUtilizationPercentage: 75
+
+resources:
+  requests:
+    cpu: 150m
+    memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
+
+env:
+  - name: FLASK_ENV
+    value: production
+  - name: EVENT_CATALOG_URL
+    value: https://catalog.meetinity.internal
+
+livenessProbe:
+  path: /healthz
+  port: http
+
+readinessProbe:
+  path: /ready
+  port: http

--- a/infra/helm/matching-service/Chart.yaml
+++ b/infra/helm/matching-service/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: matching-service
+description: Deploys the Meetinity Matching Service API.
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infra/helm/matching-service/templates/_helpers.tpl
+++ b/infra/helm/matching-service/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{- define "matching-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "matching-service.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "matching-service.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "matching-service.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "matching-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "matching-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "matching-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "matching-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- include "matching-service.fullname" . -}}
+{{- end -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/infra/helm/matching-service/templates/deployment.yaml
+++ b/infra/helm/matching-service/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "matching-service.fullname" . }}
+  labels:
+    {{- include "matching-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "matching-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "matching-service.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "matching-service.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}

--- a/infra/helm/matching-service/templates/hpa.yaml
+++ b/infra/helm/matching-service/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "matching-service.fullname" . }}
+  labels:
+    {{- include "matching-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "matching-service.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/matching-service/templates/ingress.yaml
+++ b/infra/helm/matching-service/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "matching-service.fullname" . }}
+  labels:
+    {{- include "matching-service.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ printf "%s.%s.%s" .Values.ingress.subdomain .Values.environment .Values.domain }}
+      http:
+        paths:
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "matching-service.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+  {{- if .Values.ingress.tlsSecretName }}
+  tls:
+    - secretName: {{ .Values.ingress.tlsSecretName }}
+      hosts:
+        - {{ printf "%s.%s.%s" .Values.ingress.subdomain .Values.environment .Values.domain }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/matching-service/templates/service.yaml
+++ b/infra/helm/matching-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "matching-service.fullname" . }}
+  labels:
+    {{- include "matching-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "matching-service.selectorLabels" . | nindent 4 }}

--- a/infra/helm/matching-service/templates/serviceaccount.yaml
+++ b/infra/helm/matching-service/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "matching-service.serviceAccountName" . }}
+  labels:
+    {{- include "matching-service.labels" . | nindent 4 }}
+{{- end }}

--- a/infra/helm/matching-service/values.yaml
+++ b/infra/helm/matching-service/values.yaml
@@ -1,0 +1,56 @@
+environment: dev
+domain: meetinity.com
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/meetinity/matching-service
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: ""
+
+service:
+  type: ClusterIP
+  port: 5001
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  subdomain: matching
+  tlsSecretName: matching-service-tls
+  paths:
+    - path: /
+      pathType: Prefix
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 60
+  targetMemoryUtilizationPercentage: 70
+
+resources:
+  requests:
+    cpu: 150m
+    memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
+
+env:
+  - name: FLASK_ENV
+    value: production
+  - name: MATCHING_STRATEGY
+    value: interest-based
+
+livenessProbe:
+  path: /healthz
+  port: http
+
+readinessProbe:
+  path: /ready
+  port: http

--- a/infra/helm/user-service/Chart.yaml
+++ b/infra/helm/user-service/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: user-service
+description: Deploys the Meetinity User Service API.
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infra/helm/user-service/templates/_helpers.tpl
+++ b/infra/helm/user-service/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{- define "user-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "user-service.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "user-service.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "user-service.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "user-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "user-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "user-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "user-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- include "user-service.fullname" . -}}
+{{- end -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/infra/helm/user-service/templates/deployment.yaml
+++ b/infra/helm/user-service/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "user-service.fullname" . }}
+  labels:
+    {{- include "user-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "user-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "user-service.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "user-service.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}

--- a/infra/helm/user-service/templates/hpa.yaml
+++ b/infra/helm/user-service/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "user-service.fullname" . }}
+  labels:
+    {{- include "user-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "user-service.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/user-service/templates/ingress.yaml
+++ b/infra/helm/user-service/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "user-service.fullname" . }}
+  labels:
+    {{- include "user-service.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ printf "%s.%s.%s" .Values.ingress.subdomain .Values.environment .Values.domain }}
+      http:
+        paths:
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "user-service.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+  {{- if .Values.ingress.tlsSecretName }}
+  tls:
+    - secretName: {{ .Values.ingress.tlsSecretName }}
+      hosts:
+        - {{ printf "%s.%s.%s" .Values.ingress.subdomain .Values.environment .Values.domain }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/user-service/templates/service.yaml
+++ b/infra/helm/user-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "user-service.fullname" . }}
+  labels:
+    {{- include "user-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "user-service.selectorLabels" . | nindent 4 }}

--- a/infra/helm/user-service/templates/serviceaccount.yaml
+++ b/infra/helm/user-service/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "user-service.serviceAccountName" . }}
+  labels:
+    {{- include "user-service.labels" . | nindent 4 }}
+{{- end }}

--- a/infra/helm/user-service/values.yaml
+++ b/infra/helm/user-service/values.yaml
@@ -1,0 +1,59 @@
+environment: dev
+domain: meetinity.com
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/meetinity/user-service
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: ""
+
+service:
+  type: ClusterIP
+  port: 5000
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  subdomain: users
+  tlsSecretName: user-service-tls
+  paths:
+    - path: /
+      pathType: Prefix
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 65
+  targetMemoryUtilizationPercentage: 75
+
+resources:
+  requests:
+    cpu: 150m
+    memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
+
+env:
+  - name: FLASK_ENV
+    value: production
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: user-service-db
+        key: url
+
+livenessProbe:
+  path: /healthz
+  port: http
+
+readinessProbe:
+  path: /ready
+  port: http

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,0 +1,50 @@
+# Monitoring Stack
+
+This folder contains the configuration used to deploy the Meetinity monitoring toolchain on the EKS cluster.
+
+## Components
+
+- **Prometheus Operator (kube-prometheus-stack)**: Provides Prometheus, Alertmanager, and related CRDs.
+- **Grafana**: Dashboards for application and infrastructure metrics.
+- **Alerting**: Routing rules and default notification templates for on-call rotations.
+
+## Deployment Steps
+
+1. Add the Helm repositories:
+
+   ```bash
+   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+   helm repo add grafana https://grafana.github.io/helm-charts
+   helm repo update
+   ```
+
+2. Deploy or upgrade Prometheus:
+
+   ```bash
+   helm upgrade --install monitoring prometheus-community/kube-prometheus-stack \
+     --namespace monitoring \
+     --create-namespace \
+     -f infra/monitoring/prometheus/values.yaml
+   ```
+
+3. Configure Grafana (optional override separate release). Update the ingress host in `grafana/values.yaml` before deploying:
+
+   ```bash
+   helm upgrade --install grafana grafana/grafana \
+     --namespace monitoring \
+     -f infra/monitoring/grafana/values.yaml
+   ```
+
+4. Apply Alertmanager rules if not managed by Helm:
+
+   ```bash
+   kubectl apply -n monitoring -f infra/monitoring/alertmanager/config.yaml
+   ```
+
+5. Import dashboards referenced in `grafana/values.yaml` and update credentials via Kubernetes secrets.
+
+## Operations
+
+- Use `kubectl port-forward svc/monitoring-grafana 3000:80 -n monitoring` for local access.
+- Alertmanager routes to Slack (example webhook) and email by default; update secrets referenced in the config before deploying.
+- ServiceMonitor and PodMonitor objects can be created per microservice to collect metrics automatically.

--- a/infra/monitoring/alertmanager/config.yaml
+++ b/infra/monitoring/alertmanager/config.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-config
+  namespace: monitoring
+type: Opaque
+stringData:
+  alertmanager.yaml: |
+    route:
+      receiver: default
+      group_by: ['alertname','cluster']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+    receivers:
+      - name: default
+        slack_configs:
+          - channel: '#meetinity-alerts'
+            send_resolved: true
+            api_url: ${SLACK_WEBHOOK_URL}
+        email_configs:
+          - to: sre@meetinity.com
+            send_resolved: true
+    inhibit_rules:
+      - source_matchers: ['severity = critical']
+        target_matchers: ['severity = warning']
+        equal: ['alertname', 'namespace']

--- a/infra/monitoring/grafana/values.yaml
+++ b/infra/monitoring/grafana/values.yaml
@@ -1,0 +1,55 @@
+adminUser: admin
+adminPassword: changeme
+
+env:
+  GF_SERVER_DOMAIN: grafana.dev.meetinity.com
+  GF_SERVER_ROOT_URL: https://grafana.dev.meetinity.com
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations: {}
+  hosts:
+    - grafana.dev.meetinity.com
+  tls:
+    - secretName: grafana-tls
+      hosts:
+        - grafana.dev.meetinity.com
+
+persistence:
+  enabled: true
+  storageClassName: gp2
+  size: 10Gi
+
+dashboardsConfigMaps:
+  default:
+    meetinity-overview: grafana-dashboard-meetinity
+
+sidecar:
+  dashboards:
+    enabled: true
+    label: grafana_dashboard
+  datasources:
+    enabled: true
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        url: http://monitoring-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
+        access: proxy
+        isDefault: true

--- a/infra/monitoring/prometheus/values.yaml
+++ b/infra/monitoring/prometheus/values.yaml
@@ -1,0 +1,60 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+prometheus:
+  prometheusSpec:
+    retention: 15d
+    retentionSize: 50GiB
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 1
+        memory: 2Gi
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    additionalScrapeConfigs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            target_label: __address__
+            regex: (.+)
+            replacement: $1
+alertmanager:
+  enabled: true
+  alertmanagerSpec:
+    replicas: 2
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    configSecret: alertmanager-config
+
+kubeScheduler:
+  serviceMonitor:
+    interval: 30s
+kubeControllerManager:
+  serviceMonitor:
+    interval: 30s
+
+nodeExporter:
+  enabled: true
+
+grafana:
+  enabled: false

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENVIRONMENT="${1:-dev}"
+AWS_REGION="${AWS_REGION:-eu-west-1}"
+DOMAIN="${DOMAIN:-meetinity.com}"
+TF_DIR="$(dirname "$0")/../terraform"
+HELM_DIR="$(dirname "$0")/../helm"
+MONITORING_DIR="$(dirname "$0")/../monitoring"
+SECURITY_DIR="$(dirname "$0")/../security"
+
+function log() {
+  echo "[deploy] $*"
+}
+
+log "Initialising Terraform backend"
+(cd "$TF_DIR" && terraform init -input=false)
+
+log "Applying Terraform stack"
+TF_VARS_FILE="${TF_DIR}/${ENVIRONMENT}.tfvars"
+if [[ -f "$TF_VARS_FILE" ]]; then
+  (cd "$TF_DIR" && terraform apply -input=false -auto-approve -var-file="$TF_VARS_FILE")
+else
+  (cd "$TF_DIR" && terraform apply -input=false -auto-approve -var environment="$ENVIRONMENT" -var aws_region="$AWS_REGION")
+fi
+
+log "Updating kubeconfig"
+aws eks update-kubeconfig --name "$(cd "$TF_DIR" && terraform output -raw cluster_name)" --region "$AWS_REGION"
+
+log "Deploying cert-manager"
+helm repo add jetstack https://charts.jetstack.io >/dev/null
+helm repo update >/dev/null
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace security \
+  --create-namespace \
+  --set installCRDs=true \
+  -f "$SECURITY_DIR/cert-manager/values.yaml"
+
+log "Applying ClusterIssuer and network policies"
+kubectl apply -f "$SECURITY_DIR/cluster-issuer.yaml"
+kubectl apply -f "$SECURITY_DIR/network-policies"
+
+log "Deploying application charts"
+for chart in api-gateway user-service matching-service event-service; do
+  helm upgrade --install "$chart" "$HELM_DIR/$chart" \
+    --namespace default \
+    --set environment="$ENVIRONMENT" \
+    --set domain="$DOMAIN"
+done
+
+log "Deploying monitoring stack"
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+helm repo add grafana https://grafana.github.io/helm-charts >/dev/null
+helm repo update >/dev/null
+helm upgrade --install monitoring prometheus-community/kube-prometheus-stack \
+  --namespace monitoring \
+  --create-namespace \
+  -f "$MONITORING_DIR/prometheus/values.yaml"
+helm upgrade --install grafana grafana/grafana \
+  --namespace monitoring \
+  -f "$MONITORING_DIR/grafana/values.yaml"
+kubectl apply -f "$MONITORING_DIR/alertmanager/config.yaml"
+
+log "Deployment completed"

--- a/infra/security/README.md
+++ b/infra/security/README.md
@@ -1,0 +1,40 @@
+# Security Add-ons
+
+This directory defines security-focused components for the Meetinity EKS cluster.
+
+## Contents
+
+- **cert-manager**: Automated TLS certificate management.
+- **ClusterIssuer**: Lets cert-manager issue certificates via ACME (Let's Encrypt).
+- **Network Policies**: Restrict traffic between namespaces and services.
+
+## Deployment Steps
+
+1. Install cert-manager using Helm:
+
+   ```bash
+   helm repo add jetstack https://charts.jetstack.io
+   helm repo update
+   helm upgrade --install cert-manager jetstack/cert-manager \
+     --namespace security \
+     --create-namespace \
+     --set installCRDs=true \
+     -f infra/security/cert-manager/values.yaml
+   ```
+
+2. Apply the ClusterIssuer once cert-manager CRDs are ready:
+
+   ```bash
+   kubectl apply -f infra/security/cluster-issuer.yaml
+   ```
+
+3. Enforce network policies:
+
+   ```bash
+   kubectl apply -f infra/security/network-policies/
+   ```
+
+## Operations
+
+- Update the ACME email and secret reference in `cluster-issuer.yaml` per environment.
+- When new services are added, define namespace-specific policies following the provided templates.

--- a/infra/security/cert-manager/values.yaml
+++ b/infra/security/cert-manager/values.yaml
@@ -1,0 +1,19 @@
+installCRDs: true
+
+replicaCount: 2
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 300m
+    memory: 256Mi
+
+webhook:
+  timeoutSeconds: 10
+
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true

--- a/infra/security/cluster-issuer.yaml
+++ b/infra/security/cluster-issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+  namespace: security
+spec:
+  acme:
+    email: sre@meetinity.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/infra/security/network-policies/allow-monitoring.yaml
+++ b/infra/security/network-policies/allow-monitoring.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 9090

--- a/infra/security/network-policies/allow-namespace-to-namespace.yaml
+++ b/infra/security/network-policies/allow-namespace-to-namespace.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-gateway
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api-gateway
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: user-service
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: user-service
+      ports:
+        - port: 5000
+          protocol: TCP

--- a/infra/security/network-policies/default-deny.yaml
+++ b/infra/security/network-policies/default-deny.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: default
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,60 @@
+# Meetinity Terraform Stack
+
+This Terraform configuration bootstraps the AWS infrastructure required to run the Meetinity platform on Amazon EKS.
+
+## Components
+
+- **VPC module** – Creates a multi-AZ VPC with public and private subnets, routing tables, and optional NAT gateways.
+- **EKS module** – Provisions an EKS control plane and managed node group spanning the private subnets.
+- **Kubernetes namespaces** – Pre-creates logical namespaces for monitoring and security add-ons deployed with Helm.
+
+## Usage
+
+1. Install Terraform (>= 1.5) and configure AWS credentials with rights to manage VPC, IAM and EKS resources.
+2. Initialise the working directory:
+
+   ```bash
+   terraform init
+   ```
+
+3. Review and override variables in a `.tfvars` file if needed. Example `dev.tfvars`:
+
+   ```hcl
+   environment          = "dev"
+   cluster_name         = "meetinity-dev"
+   aws_region           = "eu-west-3"
+   node_group_config = {
+     desired_size   = 2
+     max_size       = 4
+     min_size       = 1
+     instance_types = ["t3.medium"]
+     disk_size      = 40
+   }
+   ```
+
+4. Plan and apply:
+
+   ```bash
+   terraform plan -var-file=dev.tfvars
+   terraform apply -var-file=dev.tfvars
+   ```
+
+5. Once applied, configure `kubectl`:
+
+   ```bash
+   aws eks update-kubeconfig --region eu-west-3 --name $(terraform output -raw cluster_name)
+   ```
+
+   The sensitive `cluster_auth` output also contains the endpoint and CA bundle required by automation tools.
+
+## State Management
+
+Store state remotely (e.g. S3 + DynamoDB) in production by adding a backend block to `main.tf` before running `terraform init`.
+
+## Cleanup
+
+To destroy all resources created by this stack:
+
+```bash
+terraform destroy -var-file=dev.tfvars
+```

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,79 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.20"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_id
+}
+
+locals {
+  default_tags = merge({
+    Environment = var.environment,
+    Project     = "meetinity"
+  }, var.tags)
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+
+  name                 = var.network_name
+  cidr_block           = var.vpc_cidr_block
+  az_count             = var.availability_zone_count
+  private_subnet_cidrs = var.private_subnet_cidrs
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  enable_nat_gateway   = var.enable_nat_gateway
+  tags                 = local.default_tags
+}
+
+module "eks" {
+  source = "./modules/eks"
+
+  cluster_name       = var.cluster_name
+  kubernetes_version = var.kubernetes_version
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnet_ids
+  node_group_config  = var.node_group_config
+  tags               = local.default_tags
+}
+
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+}
+
+resource "kubernetes_namespace" "security" {
+  metadata {
+    name = "security"
+  }
+}
+
+output "cluster_auth" {
+  description = "Credentials required by kubectl to access the EKS cluster."
+  value = {
+    endpoint = module.eks.cluster_endpoint
+    ca_cert  = module.eks.cluster_certificate_authority_data
+  }
+  sensitive = true
+}

--- a/infra/terraform/modules/eks/main.tf
+++ b/infra/terraform/modules/eks/main.tf
@@ -1,0 +1,28 @@
+module "eks" {
+  source          = "terraform-aws-modules/eks/aws"
+  version         = "~> 20.0"
+  cluster_name    = var.cluster_name
+  cluster_version = var.kubernetes_version
+  subnet_ids      = var.private_subnet_ids
+  vpc_id          = var.vpc_id
+
+  cluster_endpoint_public_access  = true
+  cluster_endpoint_private_access = true
+
+  eks_managed_node_group_defaults = {
+    ami_type       = "AL2_x86_64"
+    disk_size      = var.node_group_config.disk_size
+    instance_types = var.node_group_config.instance_types
+  }
+
+  eks_managed_node_groups = {
+    default = {
+      desired_size = var.node_group_config.desired_size
+      max_size     = var.node_group_config.max_size
+      min_size     = var.node_group_config.min_size
+      subnet_ids   = var.private_subnet_ids
+    }
+  }
+
+  tags = var.tags
+}

--- a/infra/terraform/modules/eks/outputs.tf
+++ b/infra/terraform/modules/eks/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_id" {
+  description = "EKS cluster identifier."
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "EKS API server endpoint."
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64 encoded certificate data."
+  value       = module.eks.cluster_certificate_authority_data
+}
+
+output "node_group_role_arn" {
+  description = "IAM role ARN for the default node group."
+  value       = module.eks.eks_managed_node_groups["default"].iam_role_arn
+}

--- a/infra/terraform/modules/eks/variables.tf
+++ b/infra/terraform/modules/eks/variables.tf
@@ -1,0 +1,36 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster."
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version to deploy."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC hosting the cluster."
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs used by worker nodes."
+  type        = list(string)
+}
+
+variable "node_group_config" {
+  description = "Sizing information for managed node groups."
+  type = object({
+    desired_size   = number
+    max_size       = number
+    min_size       = number
+    instance_types = list(string)
+    disk_size      = number
+  })
+}
+
+variable "tags" {
+  description = "Resource tags."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -1,0 +1,118 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required", "opted-in"]
+  }
+}
+
+locals {
+  max_azs = min(var.az_count, length(data.aws_availability_zones.available.names))
+  azs     = slice(data.aws_availability_zones.available.names, 0, local.max_azs)
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  map_public_ip_on_launch = true
+  availability_zone       = local.azs[count.index % length(local.azs)]
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-public-${count.index}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = local.azs[count.index % length(local.azs)]
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-private-${count.index}"
+    Tier = "private"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-public"
+  })
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat" {
+  count = var.enable_nat_gateway ? 1 : 0
+  vpc   = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nat"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = var.enable_nat_gateway ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nat"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "private" {
+  count = length(aws_subnet.private)
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-private-${count.index}"
+  })
+}
+
+resource "aws_route" "private_nat" {
+  count                  = var.enable_nat_gateway ? length(aws_route_table.private) : 0
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this[0].id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the created VPC."
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs."
+  value       = [for subnet in aws_subnet.public : subnet.id]
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs."
+  value       = [for subnet in aws_subnet.private : subnet.id]
+}

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,0 +1,37 @@
+variable "name" {
+  description = "Prefix for VPC related resource names."
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "CIDR block assigned to the VPC."
+  type        = string
+}
+
+variable "az_count" {
+  description = "Number of availability zones to use."
+  type        = number
+  default     = 3
+}
+
+variable "public_subnet_cidrs" {
+  description = "List of CIDRs for public subnets."
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "List of CIDRs for private subnets."
+  type        = list(string)
+}
+
+variable "enable_nat_gateway" {
+  description = "Whether to create a NAT gateway for private subnets."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_id" {
+  description = "Identifier of the created VPC."
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets used by workloads."
+  value       = module.vpc.private_subnet_ids
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets for ingress and managed services."
+  value       = module.vpc.public_subnet_ids
+}
+
+output "cluster_name" {
+  description = "Name of the managed EKS cluster."
+  value       = module.eks.cluster_id
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint to access the Kubernetes API server."
+  value       = module.eks.cluster_endpoint
+}
+
+output "node_group_role_arn" {
+  description = "IAM role ARN used by the primary node group."
+  value       = module.eks.node_group_role_arn
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,90 @@
+variable "aws_region" {
+  description = "AWS region where resources will be created."
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "environment" {
+  description = "Deployment environment name (e.g. dev, staging, prod)."
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to created resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "network_name" {
+  description = "Base name used for VPC resources."
+  type        = string
+  default     = "meetinity-network"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zone_count" {
+  description = "Number of availability zones to span."
+  type        = number
+  default     = 3
+}
+
+variable "private_subnet_cidrs" {
+  description = "List of CIDR blocks for private subnets."
+  type        = list(string)
+  default     = [
+    "10.0.0.0/19",
+    "10.0.32.0/19",
+    "10.0.64.0/19"
+  ]
+}
+
+variable "public_subnet_cidrs" {
+  description = "List of CIDR blocks for public subnets."
+  type        = list(string)
+  default     = [
+    "10.0.96.0/20",
+    "10.0.112.0/20",
+    "10.0.128.0/20"
+  ]
+}
+
+variable "enable_nat_gateway" {
+  description = "Whether to provision a managed NAT gateway for outbound traffic from private subnets."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster."
+  type        = string
+  default     = "meetinity-eks"
+}
+
+variable "kubernetes_version" {
+  description = "Desired Kubernetes version for the cluster."
+  type        = string
+  default     = "1.29"
+}
+
+variable "node_group_config" {
+  description = "Configuration map for managed node groups."
+  type = object({
+    desired_size = number
+    max_size     = number
+    min_size     = number
+    instance_types = list(string)
+    disk_size      = number
+  })
+  default = {
+    desired_size   = 3
+    max_size       = 6
+    min_size       = 2
+    instance_types = ["t3.large"]
+    disk_size      = 50
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Terraform stack with reusable VPC and EKS modules plus documentation
- add Helm charts for Meetinity services together with deployment values and helper templates
- provide monitoring and security manifests and automation script for end-to-end deployment

## Testing
- terraform fmt -recursive infra/terraform *(fails: terraform binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d797ed084c83328adec93fbc7bd539