### PR TITLE
Add CI/CD workflows and document required automation secrets

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,35 @@
+# GitHub Workflows
+
+This directory contains the automation used to validate and deploy the Meetinity project.
+
+## Continuous Integration (`ci.yml`)
+
+The CI workflow runs on every push and pull request. It executes three independent jobs:
+
+- **Build & Lint** – Installs Node.js dependencies (when a `package-lock.json` file is present) and runs the `npm run lint` script if it exists.
+- **Tests** – Reuses the Node.js cache, reinstalls dependencies when necessary, and runs the configured `npm test` script.
+- **Security Scan** – Runs `npm audit --production` when a lock file is available to check dependencies for known vulnerabilities.
+
+Each job uses the `actions/setup-node` cache integration so that Node.js dependencies are restored automatically between runs.
+
+## Continuous Delivery (`cd.yml`)
+
+The CD workflow is triggered on pushes to the `main` branch. It builds and tags a Docker image, pushes it to Amazon ECR, and then deploys the Helm chart located at `infra/helm/api-gateway` to the target EKS cluster.
+
+The workflow expects the following secrets/variables to be defined in the repository (or organization) settings:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `AWS_ACCESS_KEY_ID` | Secret | IAM access key with permissions for ECR (push) and EKS (update kubeconfig / deploy). |
+| `AWS_SECRET_ACCESS_KEY` | Secret | Secret access key paired with `AWS_ACCESS_KEY_ID`. |
+| `AWS_REGION` | Variable or Secret | AWS region for both ECR and EKS resources (for example, `eu-west-1`). |
+| `ECR_REGISTRY` | Secret or Variable | Fully qualified ECR registry URL (e.g. `123456789012.dkr.ecr.eu-west-1.amazonaws.com`). |
+| `EKS_CLUSTER_NAME` | Secret or Variable | Name of the Amazon EKS cluster targeted by the deployment. |
+| `K8S_NAMESPACE` | Secret or Variable | Kubernetes namespace where the chart should be installed/updated. |
+
+### Optional configuration
+
+If your project uses a custom Dockerfile path, Helm release name, or chart path, update the environment variables defined at the top of `cd.yml` (defaults: `IMAGE_NAME=api-gateway`, `CHART_PATH=infra/helm/api-gateway`).
+
+For production environments, prefer using short-lived credentials with GitHub's OpenID Connect (OIDC) integration and an assumable IAM role instead of long-lived access keys.
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,78 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  IMAGE_NAME: api-gateway
+  CHART_PATH: infra/helm/api-gateway
+
+jobs:
+  deploy:
+    name: Build, Push & Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract branch name
+        id: source
+        run: echo "branch=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg GIT_SHA=${GITHUB_SHA} \
+            --tag ${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA} \
+            --tag ${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.source.outputs.branch }} \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA}
+          docker push ${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.source.outputs.branch }}
+
+      - name: Update kubeconfig for cluster
+        id: update_kubeconfig
+        run: |
+          aws eks update-kubeconfig \
+            --name ${{ secrets.EKS_CLUSTER_NAME }} \
+            --region ${{ secrets.AWS_REGION }}
+
+      - name: Create namespace if needed
+        run: |
+          kubectl create namespace ${{ secrets.K8S_NAMESPACE }} --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create or update Docker registry secret
+        run: |
+          kubectl create secret docker-registry ecr-pull-secret \
+            --namespace ${{ secrets.K8S_NAMESPACE }} \
+            --docker-server=${{ secrets.ECR_REGISTRY }} \
+            --docker-username=AWS \
+            --docker-password=$(aws ecr get-login-password --region ${{ secrets.AWS_REGION }}) \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Helm upgrade
+        run: |
+          helm upgrade --install meetinity ${{ env.CHART_PATH }} \
+            --namespace ${{ secrets.K8S_NAMESPACE }} \
+            --set image.repository=${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }} \
+            --set image.tag=${GITHUB_SHA} \
+            --set imagePullSecrets[0].name=ecr-pull-secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,107 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  build:
+    name: Build & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install Node.js dependencies
+        if: ${{ hashFiles('**/package-lock.json') != '' }}
+        run: npm ci
+
+      - name: Skip Node.js install
+        if: ${{ hashFiles('**/package-lock.json') == '' }}
+        run: echo 'No package-lock.json found. Skipping Node.js dependency installation.'
+
+      - name: Run lint
+        if: ${{ hashFiles('**/package.json') != '' }}
+        run: |
+          if npm run | grep -q "lint"; then
+            npm run lint
+          else
+            echo 'No lint script found in package.json. Skipping lint.'
+          fi
+
+      - name: Skip lint
+        if: ${{ hashFiles('**/package.json') == '' }}
+        run: echo 'No package.json found. Skipping lint.'
+
+  test:
+    name: Tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install Node.js dependencies
+        if: ${{ hashFiles('**/package-lock.json') != '' }}
+        run: npm ci
+
+      - name: Skip Node.js install
+        if: ${{ hashFiles('**/package-lock.json') == '' }}
+        run: echo 'No package-lock.json found. Skipping Node.js dependency installation.'
+
+      - name: Run tests
+        if: ${{ hashFiles('**/package.json') != '' }}
+        run: |
+          if npm run | grep -q " test"; then
+            npm test -- --watch=false || npm test
+          else
+            echo 'No test script found in package.json. Skipping tests.'
+          fi
+
+      - name: Skip tests
+        if: ${{ hashFiles('**/package.json') == '' }}
+        run: echo 'No package.json found. Skipping tests.'
+
+  security_scan:
+    name: Security Scan
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install Node.js dependencies
+        if: ${{ hashFiles('**/package-lock.json') != '' }}
+        run: npm ci
+
+      - name: Skip Node.js install
+        if: ${{ hashFiles('**/package-lock.json') == '' }}
+        run: echo 'No package-lock.json found. Skipping Node.js dependency installation.'
+
+      - name: Run npm audit
+        if: ${{ hashFiles('**/package-lock.json') != '' }}
+        run: npm audit --production
+
+      - name: Skip npm audit
+        if: ${{ hashFiles('**/package-lock.json') == '' }}
+        run: echo 'No Node.js lockfile found. Skipping npm audit.'
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Meetinity Project
 
+[![CI](https://github.com/meetinity/meetinity/actions/workflows/ci.yml/badge.svg)](https://github.com/meetinity/meetinity/actions/workflows/ci.yml)
+[![CD](https://github.com/meetinity/meetinity/actions/workflows/cd.yml/badge.svg)](https://github.com/meetinity/meetinity/actions/workflows/cd.yml)
+
 **Meetinity** is a professional networking platform designed to help users connect, discover events, and grow their professional network. This repository serves as the main entry point for the project, providing a comprehensive overview of the architecture and the different services that compose the platform.
 
 ## Project Overview
 
 The Meetinity platform is built on a microservices architecture, with a React-based mobile application and an administration portal. The project is divided into seven main repositories, each responsible for a specific part of the platform.
+
+## Automation
+
+Continuous integration and delivery pipelines are defined in [`.github/workflows`](.github/workflows). Refer to the [workflow README](.github/workflows/README.md) for the list of required secrets and additional configuration guidance.
 
 ### Architecture
 


### PR DESCRIPTION
## Summary
- add a CI workflow that runs build, test, and security scan jobs with dependency caching on every push and pull request
- add a CD workflow that publishes Docker images to ECR and deploys the Helm chart to EKS with reusable registry credentials
- document the required GitHub secrets and surface CI/CD status badges in the main README

## Testing
- not run (workflow configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d95f60dd2083328d1e2631a9d48ef1