### PR TITLE
Migrate CD pipeline to GHCR with automated retention

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,7 @@ Each job uses the `actions/setup-node` cache integration so that Node.js depende
 
 ## Continuous Delivery (`cd.yml`)
 
-The CD workflow is triggered on pushes to the `main` branch. It builds and tags a Docker image, pushes it to Amazon ECR, and then deploys the Helm chart located at `infra/helm/api-gateway` to the target EKS cluster.
+The CD workflow is triggered on pushes to the `main` branch. It builds and tags a Docker image, pushes it to GitHub Container Registry (GHCR), and then deploys the Helm chart located at `infra/helm/api-gateway` to the target EKS cluster.
 
 The workflow expects the following secrets/variables to be defined in the repository (or organization) settings:
 
@@ -23,13 +23,29 @@ The workflow expects the following secrets/variables to be defined in the reposi
 | `AWS_ACCESS_KEY_ID` | Secret | IAM access key with permissions for ECR (push) and EKS (update kubeconfig / deploy). |
 | `AWS_SECRET_ACCESS_KEY` | Secret | Secret access key paired with `AWS_ACCESS_KEY_ID`. |
 | `AWS_REGION` | Variable or Secret | AWS region for both ECR and EKS resources (for example, `eu-west-1`). |
-| `ECR_REGISTRY` | Secret or Variable | Fully qualified ECR registry URL (e.g. `123456789012.dkr.ecr.eu-west-1.amazonaws.com`). |
 | `EKS_CLUSTER_NAME` | Secret or Variable | Name of the Amazon EKS cluster targeted by the deployment. |
 | `K8S_NAMESPACE` | Secret or Variable | Kubernetes namespace where the chart should be installed/updated. |
+| `GHCR_READER_USERNAME` | Secret | Username for the organization-wide GHCR read token used by Kubernetes. |
+| `GHCR_READER_TOKEN` | Secret | Token with `read:packages` scope for GHCR pull access from the cluster. |
+| `RELEASE_ENVIRONMENT` | Secret (optional) | Environment label that drives the `env-release` tag (defaults to `production`). |
 
 ### Optional configuration
+
+| Name | Type | Description |
+|------|------|-------------|
+| `GHCR_RETENTION_TOKEN` | Secret | Fine-scoped PAT with `read:packages`, `write:packages`, and `delete:packages` used by the retention workflow when deletions require elevated privileges. |
 
 If your project uses a custom Dockerfile path, Helm release name, or chart path, update the environment variables defined at the top of `cd.yml` (defaults: `IMAGE_NAME=api-gateway`, `CHART_PATH=infra/helm/api-gateway`).
 
 For production environments, prefer using short-lived credentials with GitHub's OpenID Connect (OIDC) integration and an assumable IAM role instead of long-lived access keys.
+
+## Registry retention (`ghcr-retention.yml`)
+
+The registry retention workflow runs weekly (and on-demand) to prune GHCR package versions:
+
+- Keeps the latest 30 branch build tags (`branch-shortSHA`).
+- Preserves any version that also carries release or semantic tags.
+- Deletes orphaned versions with no tags.
+
+By default the workflow uses the repository `GITHUB_TOKEN`. Supplying `GHCR_RETENTION_TOKEN` as an organization secret grants the `delete:packages` scope when stricter registry policies are in place.
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,8 @@ on:
 env:
   IMAGE_NAME: api-gateway
   CHART_PATH: infra/helm/api-gateway
+  REGISTRY: ghcr.io
+  RELEASE_ENV_FALLBACK: production
 
 jobs:
   deploy:
@@ -15,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -28,26 +31,65 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           mask-aws-account-id: true
 
-      - name: Log in to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract branch name
-        id: source
-        run: echo "branch=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
+      - name: Derive registry scope
+        id: registry
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "owner=$owner" >> "$GITHUB_OUTPUT"
+          echo "REGISTRY_OWNER=$owner" >> "$GITHUB_ENV"
+
+      - name: Set image tagging metadata
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          branch="${GITHUB_REF_NAME}"
+          branch=${branch//\//-}
+          branch=$(echo "$branch" | tr '[:upper:]' '[:lower:]')
+          branch=$(echo "$branch" | sed 's/[^a-z0-9_.-]/-/g')
+          chart_file="${{ env.CHART_PATH }}/Chart.yaml"
+          app_version=$(grep '^appVersion:' "$chart_file" | head -n1 | awk '{print $2}' | tr -d '"')
+          if [ -z "$app_version" ]; then
+            app_version=$(grep '^version:' "$chart_file" | head -n1 | awk '{print $2}' | tr -d '"')
+          fi
+          if [ -z "$app_version" ]; then
+            echo "Unable to determine app version from $chart_file" >&2
+            exit 1
+          fi
+
+          release_env="${{ secrets.RELEASE_ENVIRONMENT }}"
+          if [ -z "$release_env" ]; then
+            release_env="${{ env.RELEASE_ENV_FALLBACK }}"
+          fi
+          release_env=$(echo "$release_env" | tr '[:upper:]' '[:lower:]')
+          release_env=$(echo "$release_env" | sed 's/[^a-z0-9_.-]/-/g')
+
+          echo "SHORT_SHA=$short_sha" >> "$GITHUB_ENV"
+          echo "BRANCH_NAME=$branch" >> "$GITHUB_ENV"
+          echo "APP_VERSION=$app_version" >> "$GITHUB_ENV"
+          echo "RELEASE_ENV=$release_env" >> "$GITHUB_ENV"
+          image_uri="${{ env.REGISTRY }}/${REGISTRY_OWNER}/${{ env.IMAGE_NAME }}"
+          echo "IMAGE_URI=$image_uri" >> "$GITHUB_ENV"
 
       - name: Build Docker image
         run: |
           docker build \
             --build-arg GIT_SHA=${GITHUB_SHA} \
-            --tag ${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA} \
-            --tag ${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.source.outputs.branch }} \
+            --tag ${IMAGE_URI}:${BRANCH_NAME}-${SHORT_SHA} \
+            --tag ${IMAGE_URI}:${RELEASE_ENV}-release \
+            --tag ${IMAGE_URI}:${APP_VERSION} \
             .
 
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA}
-          docker push ${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.source.outputs.branch }}
+          docker push ${IMAGE_URI}:${BRANCH_NAME}-${SHORT_SHA}
+          docker push ${IMAGE_URI}:${RELEASE_ENV}-release
+          docker push ${IMAGE_URI}:${APP_VERSION}
 
       - name: Update kubeconfig for cluster
         id: update_kubeconfig
@@ -62,17 +104,17 @@ jobs:
 
       - name: Create or update Docker registry secret
         run: |
-          kubectl create secret docker-registry ecr-pull-secret \
+          kubectl create secret docker-registry ghcr-pull-secret \
             --namespace ${{ secrets.K8S_NAMESPACE }} \
-            --docker-server=${{ secrets.ECR_REGISTRY }} \
-            --docker-username=AWS \
-            --docker-password=$(aws ecr get-login-password --region ${{ secrets.AWS_REGION }}) \
+            --docker-server=${{ env.REGISTRY }} \
+            --docker-username=${{ secrets.GHCR_READER_USERNAME }} \
+            --docker-password=${{ secrets.GHCR_READER_TOKEN }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Helm upgrade
         run: |
           helm upgrade --install meetinity ${{ env.CHART_PATH }} \
             --namespace ${{ secrets.K8S_NAMESPACE }} \
-            --set image.repository=${{ secrets.ECR_REGISTRY }}/${{ env.IMAGE_NAME }} \
-            --set image.tag=${GITHUB_SHA} \
-            --set imagePullSecrets[0].name=ecr-pull-secret
+            --set image.repository=${IMAGE_URI} \
+            --set image.tag=${BRANCH_NAME}-${SHORT_SHA} \
+            --set imagePullSecrets[0].name=ghcr-pull-secret

--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -1,0 +1,135 @@
+name: GHCR Retention
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+env:
+  PACKAGE_NAME: api-gateway
+  BRANCH_BUILD_RETENTION: '30'
+
+jobs:
+  prune:
+    name: Prune stale container images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Prune GHCR package versions
+        uses: actions/github-script@v7
+        env:
+          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+          BRANCH_BUILD_RETENTION: ${{ env.BRANCH_BUILD_RETENTION }}
+        with:
+          github-token: ${{ secrets.GHCR_RETENTION_TOKEN || github.token }}
+          script: |
+            const core = require('@actions/core');
+            const owner = context.repo.owner;
+            let isOrg = true;
+            try {
+              await github.rest.orgs.get({ org: owner });
+            } catch (error) {
+              if (error.status === 404) {
+                isOrg = false;
+              } else {
+                throw error;
+              }
+            }
+
+            const keepCount = parseInt(process.env.BRANCH_BUILD_RETENTION, 10) || 30;
+            const packageName = process.env.PACKAGE_NAME;
+            const packageType = 'container';
+
+            const listParams = {
+              package_type: packageType,
+              package_name: packageName,
+              per_page: 100
+            };
+            if (isOrg) {
+              listParams.org = owner;
+            } else {
+              listParams.username = owner;
+            }
+
+            const listFn = isOrg
+              ? github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg
+              : github.rest.packages.getAllPackageVersionsForPackageOwnedByUser;
+
+            const versions = await github.paginate(listFn, listParams);
+
+            const branchPattern = /^[a-z0-9_.-]+-[0-9a-f]{7}$/;
+            const protectedIds = new Set();
+            const branchVersions = [];
+            const orphanIds = new Set();
+
+            for (const version of versions) {
+              const tags = version.metadata?.container?.tags ?? [];
+              if (tags.length === 0) {
+                orphanIds.add(version.id);
+                continue;
+              }
+
+              let hasBranchTag = false;
+              let hasProtectedTag = false;
+              for (const tag of tags) {
+                if (branchPattern.test(tag)) {
+                  hasBranchTag = true;
+                } else {
+                  hasProtectedTag = true;
+                }
+              }
+
+              if (hasProtectedTag) {
+                protectedIds.add(version.id);
+              }
+              if (hasBranchTag) {
+                branchVersions.push(version);
+              }
+            }
+
+            branchVersions.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            const deletions = new Map();
+
+            for (let index = keepCount; index < branchVersions.length; index += 1) {
+              const version = branchVersions[index];
+              if (!protectedIds.has(version.id)) {
+                deletions.set(version.id, version);
+              }
+            }
+
+            for (const orphanId of orphanIds) {
+              if (!protectedIds.has(orphanId)) {
+                const version = versions.find((v) => v.id === orphanId);
+                if (version) {
+                  deletions.set(orphanId, version);
+                }
+              }
+            }
+
+            if (deletions.size === 0) {
+              core.info('No container versions needed pruning.');
+              return;
+            }
+
+            const deleteFn = isOrg
+              ? github.rest.packages.deletePackageVersionForOrg
+              : github.rest.packages.deletePackageVersionForUser;
+
+            for (const version of deletions.values()) {
+              const params = {
+                package_type: packageType,
+                package_name: packageName,
+                package_version_id: version.id
+              };
+              if (isOrg) {
+                params.org = owner;
+              } else {
+                params.username = owner;
+              }
+
+              await deleteFn(params);
+              core.info(`Deleted package version ${version.id} (${version.created_at})`);
+            }

--- a/docs/container-registry.md
+++ b/docs/container-registry.md
@@ -1,0 +1,64 @@
+# Container Registry Strategy
+
+This document defines how container images are published, tagged, authenticated, and retired for Meetinity.
+
+## Hosting platform
+
+Meetinity stores container images in **GitHub Container Registry (GHCR)** under the organization namespace (`ghcr.io/<org>/<image>`). GHCR is backed by the same identity provider as GitHub and gives us:
+
+- First-class integration with GitHub Actions via the built-in `GITHUB_TOKEN`.
+- Organization level permissions that can be delegated independently to build (write) and runtime (read) personas.
+- Native lifecycle APIs for automation (retention and purge jobs).
+
+Existing environments should migrate any ECR references to GHCR using the updated `IMAGE_URI` published by the CD workflow.
+
+## Authentication model
+
+Two types of tokens are required and are configured at the organization level so that repositories and runtime clusters reuse the same credentials.
+
+| Persona | Token | Scope | Storage |
+|---------|-------|-------|---------|
+| CI/CD writers | Built-in `GITHUB_TOKEN` | `packages:write` | Automatically available to workflows when `permissions.packages: write` is set. |
+| Runtime readers | Fine-scoped personal access token (classic) with `read:packages` or GH App installation token | Saved as org secret `GHCR_READER_TOKEN` with companion username secret `GHCR_READER_USERNAME`. |
+| Retention automation | Fine-scoped PAT (classic) with `read:packages`, `write:packages`, `delete:packages` | Saved as optional org secret `GHCR_RETENTION_TOKEN`. The workflow falls back to `GITHUB_TOKEN` when the PAT is not supplied. |
+
+Runtime clusters reference the reader token via the Kubernetes pull secret `ghcr-pull-secret`, which is managed by the CD workflow.
+
+## Tagging scheme
+
+Every build publishes three immutable tags so that stakeholders can pull images by deployment, environment, or semantic version:
+
+- `app:branch-SHORT_SHA` – immutable build tag, derived from the branch name (sanitized to kebab-case) and the 7-character commit SHA.
+- `app:env-release` – mutable release pointer updated on every deployment to a given environment (defaults to `production` but can be overridden with the `RELEASE_ENVIRONMENT` secret).
+- `app:version` – semantic version sourced from `infra/helm/api-gateway/Chart.yaml` (`appVersion` fallback to `version`).
+
+The CD workflow enforces this scheme by failing the pipeline when the version cannot be inferred and by pushing the three tags on every deployment.
+
+## Publication workflow
+
+1. GitHub Actions builds the Docker image and logs in to GHCR using the repository's `GITHUB_TOKEN` (packages: write).
+2. The workflow tags the image using the scheme above and pushes all tags to `ghcr.io/<org>/api-gateway`.
+3. The Kubernetes pull secret is (re)created with the organization-wide runtime credentials so that workload pods keep access to GHCR.
+4. Helm is upgraded with the immutable branch/SHA tag, guaranteeing reproducible rollouts.
+
+### Release environment override
+
+Set the organization secret `RELEASE_ENVIRONMENT` (for example `staging`, `production`) when you need the `env-release` tag to target a specific namespace. The CD workflow lowercases and sanitizes the value to make it registry-safe.
+
+## Retention and purge
+
+Automated retention is handled by the scheduled workflow `.github/workflows/ghcr-retention.yml`:
+
+- Keeps the last **30** branch build images that only contain `branch-shortSHA` tags.
+- Preserves images that also carry release or semantic version tags.
+- Removes orphaned container versions (no tags).
+- Uses the optional `GHCR_RETENTION_TOKEN` secret when available to satisfy the `delete:packages` scope.
+
+Manual purge procedure:
+
+1. Trigger the "GHCR Retention" workflow manually (`workflow_dispatch`) and confirm that the job deletes the intended versions.
+2. For emergency purges, run the workflow with `GHCR_RETENTION_TOKEN` present so deletions succeed even if branch builds are protected by org policies.
+3. Validate that the latest `env-release` and semantic version tags still exist by listing package tags in the GitHub UI or via `crane ls ghcr.io/<org>/api-gateway`.
+4. If additional cleanup is needed (e.g., deprecating a semantic version), delete the tag in the GitHub UI which will detach it from its container version; the retention workflow will pick up the orphaned version on the next run.
+
+Document owners should update this guide whenever the Helm chart path, registry namespace, or tagging strategy changes.

--- a/docs/containerization-roadmap.md
+++ b/docs/containerization-roadmap.md
@@ -28,7 +28,7 @@ Cette feuille de route détaille les actions nécessaires pour livrer la premiè
   5. Documenter la procédure de publication et de purge.
 - **Livrables** :
   - Registre opérationnel + secrets CI/CD configurés.
-  - Politique de tagging et rétention décrite dans la documentation d'infra.
+  - Politique de tagging et rétention décrite dans la documentation d'infra (`docs/container-registry.md`).
 
 ## 3. Déployer un cluster Kubernetes avec configuration réseau et stockage
 - **Objectifs** :


### PR DESCRIPTION
## Summary
- migrate the CD workflow to publish images to GHCR with branch/env/version tagging and a GHCR pull secret
- document the container registry strategy, authentication model, and publication/purge procedures
- add a scheduled retention workflow that prunes stale GHCR images and update workflow docs with new secrets

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d99805ab388332bfff0d5a2d90dded