### PR TITLE
Provision EKS platform add-ons and document access

### DIFF
--- a/infra/terraform/kubernetes/README.md
+++ b/infra/terraform/kubernetes/README.md
@@ -1,0 +1,18 @@
+# Kubernetes Platform Decision Record
+
+## Managed Control Plane
+- **Provider:** Amazon Elastic Kubernetes Service (EKS)
+- **Region:** eu-west-1 (Ireland)
+
+EKS is aligned with our existing AWS footprint and allows us to reuse IAM, networking and
+monitoring primitives already provisioned for the platform. The `eu-west-1` region offers
+three availability zones for high availability while staying close to our primary user base
+in Europe.
+
+## Implications
+- Terraform code in this repository provisions all foundational infrastructure required to
+  run the cluster (VPC, IAM, managed node groups, add-ons).
+- Team members should request onboarding to the `meetinity-eks-admin` IAM role to obtain
+  `kubectl` access (see `docs/dev-environment.md`).
+- Workloads relying on managed services in other regions may incur cross-region latency; new
+  services should be deployed in `eu-west-1` by default.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.20"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.11"
+    }
   }
 }
 
@@ -21,6 +25,14 @@ provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
 }
 
 data "aws_eks_cluster_auth" "this" {
@@ -54,6 +66,8 @@ module "eks" {
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
   node_group_config  = var.node_group_config
+  cluster_admin_role_name      = var.cluster_admin_role_name
+  cluster_admin_principal_arns = var.cluster_admin_principal_arns
   tags               = local.default_tags
 }
 
@@ -67,6 +81,117 @@ resource "kubernetes_namespace" "security" {
   metadata {
     name = "security"
   }
+}
+
+resource "kubernetes_namespace" "cert_manager" {
+  metadata {
+    name = "cert-manager"
+  }
+}
+
+resource "kubernetes_namespace" "ingress" {
+  metadata {
+    name = "ingress-nginx"
+  }
+}
+
+locals {
+  cluster_issuer_name        = "selfsigned-cluster-issuer"
+  ingress_default_tls_secret = var.default_tls_secret_name
+}
+
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = "v1.14.4"
+  namespace        = kubernetes_namespace.cert_manager.metadata[0].name
+  create_namespace = false
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+  depends_on = [module.eks]
+}
+
+resource "kubernetes_manifest" "self_signed_cluster_issuer" {
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "ClusterIssuer"
+    metadata = {
+      name = local.cluster_issuer_name
+    }
+    spec = {
+      selfSigned = {}
+    }
+  }
+
+  depends_on = [helm_release.cert_manager]
+}
+
+resource "kubernetes_manifest" "default_tls_certificate" {
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "Certificate"
+    metadata = {
+      name      = "default-ingress-tls"
+      namespace = kubernetes_namespace.ingress.metadata[0].name
+    }
+    spec = {
+      dnsNames   = var.default_tls_dns_names
+      secretName = local.ingress_default_tls_secret
+      issuerRef = {
+        kind = "ClusterIssuer"
+        name = local.cluster_issuer_name
+      }
+      usages = ["digital signature", "key encipherment"]
+    }
+  }
+
+  depends_on = [kubernetes_manifest.self_signed_cluster_issuer]
+}
+
+resource "helm_release" "ingress_nginx" {
+  name       = "ingress-nginx"
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  version    = "4.10.0"
+  namespace  = kubernetes_namespace.ingress.metadata[0].name
+
+  set {
+    name  = "controller.service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-type"
+    value = "nlb"
+  }
+
+  set {
+    name  = "controller.extraArgs.default-ssl-certificate"
+    value = "${kubernetes_namespace.ingress.metadata[0].name}/${local.ingress_default_tls_secret}"
+  }
+
+  depends_on = [kubernetes_manifest.default_tls_certificate]
+}
+
+resource "kubernetes_storage_class" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    type  = "gp3"
+    fsType = "ext4"
+  }
+
+  depends_on = [module.eks]
 }
 
 output "cluster_auth" {

--- a/infra/terraform/modules/eks/main.tf
+++ b/infra/terraform/modules/eks/main.tf
@@ -1,3 +1,13 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  cluster_admin_principals = distinct(
+    concat([
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+    ], var.cluster_admin_principal_arns)
+  )
+}
+
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
   version         = "~> 20.0"
@@ -5,6 +15,8 @@ module "eks" {
   cluster_version = var.kubernetes_version
   subnet_ids      = var.private_subnet_ids
   vpc_id          = var.vpc_id
+
+  enable_irsa = true
 
   cluster_endpoint_public_access  = true
   cluster_endpoint_private_access = true
@@ -25,4 +37,105 @@ module "eks" {
   }
 
   tags = var.tags
+}
+
+data "aws_iam_policy_document" "cluster_admin_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = local.cluster_admin_principals
+    }
+  }
+}
+
+resource "aws_iam_role" "cluster_admin" {
+  name               = var.cluster_admin_role_name
+  assume_role_policy = data.aws_iam_policy_document.cluster_admin_assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_admin_admin_access" {
+  role       = aws_iam_role.cluster_admin.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_eks_access_entry" "cluster_admin" {
+  cluster_name  = module.eks.cluster_name
+  principal_arn = aws_iam_role.cluster_admin.arn
+  type          = "STANDARD"
+}
+
+resource "aws_eks_access_policy_association" "cluster_admin" {
+  cluster_name  = module.eks.cluster_name
+  principal_arn = aws_iam_role.cluster_admin.arn
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+}
+
+data "aws_iam_policy_document" "ebs_csi_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.oidc_provider, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+    }
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "ebs_csi" {
+  name               = "${var.cluster_name}-ebs-csi"
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi" {
+  role       = aws_iam_role.ebs_csi.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name                = module.eks.cluster_name
+  addon_name                  = "vpc-cni"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  tags                        = var.tags
+}
+
+resource "aws_eks_addon" "coredns" {
+  cluster_name                = module.eks.cluster_name
+  addon_name                  = "coredns"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  tags                        = var.tags
+}
+
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name                = module.eks.cluster_name
+  addon_name                  = "kube-proxy"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  tags                        = var.tags
+}
+
+resource "aws_eks_addon" "ebs_csi" {
+  cluster_name                = module.eks.cluster_name
+  addon_name                  = "aws-ebs-csi-driver"
+  service_account_role_arn    = aws_iam_role.ebs_csi.arn
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  tags                        = var.tags
 }

--- a/infra/terraform/modules/eks/outputs.tf
+++ b/infra/terraform/modules/eks/outputs.tf
@@ -17,3 +17,18 @@ output "node_group_role_arn" {
   description = "IAM role ARN for the default node group."
   value       = module.eks.eks_managed_node_groups["default"].iam_role_arn
 }
+
+output "cluster_admin_role_arn" {
+  description = "IAM role ARN that maps to Kubernetes cluster-admin permissions."
+  value       = aws_iam_role.cluster_admin.arn
+}
+
+output "ebs_csi_role_arn" {
+  description = "IAM role ARN associated with the EBS CSI driver service account."
+  value       = aws_iam_role.ebs_csi.arn
+}
+
+output "ebs_csi_addon_id" {
+  description = "Identifier of the aws-ebs-csi-driver managed add-on."
+  value       = aws_eks_addon.ebs_csi.id
+}

--- a/infra/terraform/modules/eks/variables.tf
+++ b/infra/terraform/modules/eks/variables.tf
@@ -29,6 +29,18 @@ variable "node_group_config" {
   })
 }
 
+variable "cluster_admin_role_name" {
+  description = "Name of the IAM role granting administrative access to the cluster."
+  type        = string
+  default     = "meetinity-eks-admin"
+}
+
+variable "cluster_admin_principal_arns" {
+  description = "Additional IAM principal ARNs allowed to assume the admin role."
+  type        = list(string)
+  default     = []
+}
+
 variable "tags" {
   description = "Resource tags."
   type        = map(string)

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -27,3 +27,13 @@ output "node_group_role_arn" {
   description = "IAM role ARN used by the primary node group."
   value       = module.eks.node_group_role_arn
 }
+
+output "cluster_admin_role_arn" {
+  description = "IAM role ARN that administrators must assume for kubectl access."
+  value       = module.eks.cluster_admin_role_arn
+}
+
+output "ebs_csi_role_arn" {
+  description = "IAM role ARN associated with the EBS CSI controller service account."
+  value       = module.eks.ebs_csi_role_arn
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -88,3 +88,27 @@ variable "node_group_config" {
     disk_size      = 50
   }
 }
+
+variable "cluster_admin_role_name" {
+  description = "Friendly name for the IAM role mapped to Kubernetes cluster-admin."
+  type        = string
+  default     = "meetinity-eks-admin"
+}
+
+variable "cluster_admin_principal_arns" {
+  description = "IAM principal ARNs allowed to assume the cluster-admin role in addition to the account root."
+  type        = list(string)
+  default     = []
+}
+
+variable "default_tls_dns_names" {
+  description = "DNS names included in the default ingress TLS certificate."
+  type        = list(string)
+  default     = ["meetinity.local"]
+}
+
+variable "default_tls_secret_name" {
+  description = "Name of the Kubernetes secret storing the default ingress TLS certificate."
+  type        = string
+  default     = "meetinity-ingress-tls"
+}


### PR DESCRIPTION
## Summary
- capture the decision to run Meetinity on Amazon EKS in eu-west-1 and expose new Terraform variables for admin access and TLS defaults
- extend the EKS module with cluster-admin IAM role mapping, AWS managed add-ons, and CSI driver IAM integration
- bootstrap cert-manager, ingress-nginx, default TLS assets, and a gp3 storage class while documenting kubectl onboarding

## Testing
- terraform -chdir=infra/terraform fmt *(fails: terraform CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d99993439c8332ad0885dcc5d6ee26