### PR TITLE
feat: add blue-green deploy automation and perf/security CI checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,13 +4,16 @@ This directory contains the automation used to validate and deploy the Meetinity
 
 ## Continuous Integration (`ci.yml`)
 
-The CI workflow runs on every push and pull request. It executes three independent jobs:
+The CI workflow runs on every push and pull request. It now orchestrates a broader validation matrix:
 
 - **Build & Lint** – Installs Node.js dependencies (when a `package-lock.json` file is present) and runs the `npm run lint` script if it exists.
 - **Tests** – Reuses the Node.js cache, reinstalls dependencies when necessary, and runs the configured `npm test` script.
 - **Security Scan** – Runs `npm audit --production` when a lock file is available to check dependencies for known vulnerabilities.
+- **Performance tests (k6)** – Executes `tests/performance/smoke.js` with Grafana k6. Threshold failures fail the workflow and the JSON summaries are uploaded as the `k6-performance-report` artifact so that run statistics can be reviewed offline.
+- **OWASP ZAP baseline scan** – Launches a lightweight active scan against the target URL (configurable through the `ZAP_TARGET_URL` repository/organization variable) and stores the resulting HTML/JSON bundle as `zap-baseline-report`.
+- **Trivy filesystem scan** – Scans the repository contents for vulnerable dependencies and packages. Findings are exported as `trivy-report.json` and shared via the `trivy-vulnerability-report` artifact.
 
-Each job uses the `actions/setup-node` cache integration so that Node.js dependencies are restored automatically between runs.
+Each job uses the `actions/setup-node` cache integration so that Node.js dependencies are restored automatically between runs. Reports produced by the new performance and security stages are retained as workflow artifacts for traceability and regression analysis.
 
 ## Continuous Delivery (`cd.yml`)
 
@@ -18,7 +21,7 @@ The CD workflow promotes tagged releases through each Kubernetes environment. It
 
 Container images are built from the repository root and published to GitHub Container Registry (GHCR). Helm deploys the umbrella chart at `infra/helm/meetinity` while layering per-environment overrides from `infra/helm/meetinity/values/<environment>.yaml`. Namespace policies, quotas, and other baseline resources live under `infra/kubernetes/environments/<environment>/namespace.yaml`; the workflow applies these manifests before running Helm so operators should update them when adjusting limits or admission controls.
 
-Deployments run sequentially—`dev` → `staging` → `prod`—so a failure in an earlier environment blocks promotion to the next stage.
+Deployments run sequentially—`dev` → `staging` → `prod`—so a failure in an earlier environment blocks promotion to the next stage. Each deployment executes a blue/green upgrade via Helm by setting `global.rolloutStrategy=blueGreen` (overridable through environment-specific variables described below). If the upgrade fails at any point, the workflow automatically runs `helm rollback` to restore the last successful revision and prevent partial rollouts.
 
 ### Required secrets and variables
 
@@ -38,6 +41,9 @@ The workflow also expects the environment manifests referenced at `infra/kuberne
 | Name | Type | Description |
 |------|------|-------------|
 | `GHCR_RETENTION_TOKEN` | Secret | Fine-scoped PAT with `read:packages`, `write:packages`, and `delete:packages` used by the retention workflow when deletions require elevated privileges. |
+| `DEV_DEPLOYMENT_STRATEGY` / `STAGING_DEPLOYMENT_STRATEGY` / `PROD_DEPLOYMENT_STRATEGY` | Variable | Override the default `blueGreen` strategy passed to the Helm chart for each environment (for example `canary`). |
+| `K6_TARGET_URL` | Variable | Custom endpoint for the k6 smoke test job; defaults to `https://test-api.k6.io/public/crocodiles/1/`. |
+| `ZAP_TARGET_URL` | Variable | Override the default target scanned by the OWASP ZAP baseline job. |
 
 If your project uses a custom Dockerfile path, release name, or chart path, update the environment variables defined at the top of `cd.yml` (defaults: `IMAGE_NAME=api-gateway`, `CHART_PATH=infra/helm/meetinity`, `VALUES_PATH=infra/helm/meetinity/values`).
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -107,6 +107,7 @@ jobs:
       VALUES_FILE: infra/helm/meetinity/values/dev.yaml
       ENVIRONMENT_KEY: dev
       K8S_MANIFEST: infra/kubernetes/environments/dev/namespace.yaml
+      DEPLOYMENT_STRATEGY: ${{ vars.DEV_DEPLOYMENT_STRATEGY || 'blueGreen' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -138,23 +139,45 @@ jobs:
             --docker-password=${{ secrets.GHCR_READER_TOKEN }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - name: Deploy chart
+      - name: Deploy chart with blue/green strategy
         run: |
+          set -euo pipefail
           owner="${{ needs.build.outputs.owner }}"
           version="${{ needs.build.outputs.release_version }}"
+          strategy="${DEPLOYMENT_STRATEGY:-blueGreen}"
+
           extra_args=()
           for svc in $SERVICES; do
             extra_args+=(--set-string "${svc}.image.repository=${{ env.REGISTRY }}/$owner/${svc}")
             extra_args+=(--set-string "${svc}.image.tag=${version}")
           done
 
+          previous_revision=$(helm history "${RELEASE_NAME}" --namespace "${NAMESPACE}" 2>/dev/null \
+            | awk 'NR>1 && toupper($3)=="DEPLOYED" {rev=$1} END {print rev}')
+
+          rollback() {
+            if [ -n "$previous_revision" ]; then
+              echo "Triggering rollback to revision $previous_revision" >&2
+              helm rollback "${RELEASE_NAME}" "$previous_revision" --namespace "${NAMESPACE}" || true
+            else
+              echo "No successful revision found for rollback. Cleaning up failed release." >&2
+              helm uninstall "${RELEASE_NAME}" --namespace "${NAMESPACE}" || true
+            fi
+          }
+
+          trap 'rollback' ERR
+
           helm upgrade --install "${RELEASE_NAME}" "${{ env.CHART_PATH }}" \
             --namespace "${NAMESPACE}" \
             --values "${{ env.CHART_PATH }}/values.yaml" \
             --values "${VALUES_FILE}" \
             --set-string global.environment="${ENVIRONMENT_KEY}" \
+            --set-string global.rolloutStrategy="${strategy}" \
+            --set-string global.enableBlueGreen=true \
             "${extra_args[@]}" \
             --wait
+
+          trap - ERR
 
       - name: Wait for workloads
         run: |
@@ -182,6 +205,7 @@ jobs:
       VALUES_FILE: infra/helm/meetinity/values/staging.yaml
       ENVIRONMENT_KEY: staging
       K8S_MANIFEST: infra/kubernetes/environments/staging/namespace.yaml
+      DEPLOYMENT_STRATEGY: ${{ vars.STAGING_DEPLOYMENT_STRATEGY || 'blueGreen' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -213,23 +237,45 @@ jobs:
             --docker-password=${{ secrets.GHCR_READER_TOKEN }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - name: Deploy chart
+      - name: Deploy chart with blue/green strategy
         run: |
+          set -euo pipefail
           owner="${{ needs.build.outputs.owner }}"
           version="${{ needs.build.outputs.release_version }}"
+          strategy="${DEPLOYMENT_STRATEGY:-blueGreen}"
+
           extra_args=()
           for svc in $SERVICES; do
             extra_args+=(--set-string "${svc}.image.repository=${{ env.REGISTRY }}/$owner/${svc}")
             extra_args+=(--set-string "${svc}.image.tag=${version}")
           done
 
+          previous_revision=$(helm history "${RELEASE_NAME}" --namespace "${NAMESPACE}" 2>/dev/null \
+            | awk 'NR>1 && toupper($3)=="DEPLOYED" {rev=$1} END {print rev}')
+
+          rollback() {
+            if [ -n "$previous_revision" ]; then
+              echo "Triggering rollback to revision $previous_revision" >&2
+              helm rollback "${RELEASE_NAME}" "$previous_revision" --namespace "${NAMESPACE}" || true
+            else
+              echo "No successful revision found for rollback. Cleaning up failed release." >&2
+              helm uninstall "${RELEASE_NAME}" --namespace "${NAMESPACE}" || true
+            fi
+          }
+
+          trap 'rollback' ERR
+
           helm upgrade --install "${RELEASE_NAME}" "${{ env.CHART_PATH }}" \
             --namespace "${NAMESPACE}" \
             --values "${{ env.CHART_PATH }}/values.yaml" \
             --values "${VALUES_FILE}" \
             --set-string global.environment="${ENVIRONMENT_KEY}" \
+            --set-string global.rolloutStrategy="${strategy}" \
+            --set-string global.enableBlueGreen=true \
             "${extra_args[@]}" \
             --wait
+
+          trap - ERR
 
       - name: Wait for workloads
         run: |
@@ -257,6 +303,7 @@ jobs:
       VALUES_FILE: infra/helm/meetinity/values/prod.yaml
       ENVIRONMENT_KEY: prod
       K8S_MANIFEST: infra/kubernetes/environments/prod/namespace.yaml
+      DEPLOYMENT_STRATEGY: ${{ vars.PROD_DEPLOYMENT_STRATEGY || 'blueGreen' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -288,23 +335,45 @@ jobs:
             --docker-password=${{ secrets.GHCR_READER_TOKEN }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - name: Deploy chart
+      - name: Deploy chart with blue/green strategy
         run: |
+          set -euo pipefail
           owner="${{ needs.build.outputs.owner }}"
           version="${{ needs.build.outputs.release_version }}"
+          strategy="${DEPLOYMENT_STRATEGY:-blueGreen}"
+
           extra_args=()
           for svc in $SERVICES; do
             extra_args+=(--set-string "${svc}.image.repository=${{ env.REGISTRY }}/$owner/${svc}")
             extra_args+=(--set-string "${svc}.image.tag=${version}")
           done
 
+          previous_revision=$(helm history "${RELEASE_NAME}" --namespace "${NAMESPACE}" 2>/dev/null \
+            | awk 'NR>1 && toupper($3)=="DEPLOYED" {rev=$1} END {print rev}')
+
+          rollback() {
+            if [ -n "$previous_revision" ]; then
+              echo "Triggering rollback to revision $previous_revision" >&2
+              helm rollback "${RELEASE_NAME}" "$previous_revision" --namespace "${NAMESPACE}" || true
+            else
+              echo "No successful revision found for rollback. Cleaning up failed release." >&2
+              helm uninstall "${RELEASE_NAME}" --namespace "${NAMESPACE}" || true
+            fi
+          }
+
+          trap 'rollback' ERR
+
           helm upgrade --install "${RELEASE_NAME}" "${{ env.CHART_PATH }}" \
             --namespace "${NAMESPACE}" \
             --values "${{ env.CHART_PATH }}/values.yaml" \
             --values "${VALUES_FILE}" \
             --set-string global.environment="${ENVIRONMENT_KEY}" \
+            --set-string global.rolloutStrategy="${strategy}" \
+            --set-string global.enableBlueGreen=true \
             "${extra_args[@]}" \
             --wait
+
+          trap - ERR
 
       - name: Wait for workloads
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,5 +199,81 @@ jobs:
       - name: Render staging manifests
         run: helm template meetinity infra/helm/meetinity --values infra/helm/meetinity/values.yaml --values infra/helm/meetinity/values/staging.yaml
 
+  performance_tests:
+    name: Performance tests (k6)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up k6
+        uses: grafana/setup-k6-action@v0.5.0
+
+      - name: Run k6 smoke test
+        run: |
+          set -euo pipefail
+          mkdir -p reports/performance
+          k6 run tests/performance/smoke.js \
+            --summary-export=reports/performance/summary.json \
+            --out json=reports/performance/results.json
+        env:
+          K6_TARGET_URL: ${{ vars.K6_TARGET_URL || 'https://test-api.k6.io/public/crocodiles/1/' }}
+
+      - name: Upload k6 report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-performance-report
+          path: reports/performance
+          if-no-files-found: warn
+
+  zap_scan:
+    name: OWASP ZAP baseline scan
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run ZAP baseline scan
+        uses: zaproxy/action-baseline@v0.9.0
+        with:
+          target: ${{ vars.ZAP_TARGET_URL || 'https://test-api.k6.io' }}
+          cmd_options: '-a -j'
+          allow_issue_warnings: true
+          fail_action: false
+
+      - name: Upload ZAP artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-baseline-report
+          path: |
+            zap*
+            report_html/**
+          if-no-files-found: warn
+
+  trivy_scan:
+    name: Trivy filesystem scan
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.21.0
+        with:
+          scan-type: fs
+          format: json
+          output: trivy-report.json
+          ignore-unfixed: true
+
+      - name: Upload Trivy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-vulnerability-report
+          path: trivy-report.json
+          if-no-files-found: warn
+
       - name: Render prod manifests
         run: helm template meetinity infra/helm/meetinity --values infra/helm/meetinity/values.yaml --values infra/helm/meetinity/values/prod.yaml

--- a/tests/performance/smoke.js
+++ b/tests/performance/smoke.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 5,
+  duration: '30s',
+  thresholds: {
+    http_req_duration: ['p(95)<800'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+const defaultTarget = 'https://test-api.k6.io/public/crocodiles/1/';
+
+export default function () {
+  const target = `${__ENV.K6_TARGET_URL || defaultTarget}`;
+  const response = http.get(target);
+  check(response, {
+    'response status is 200': (res) => res.status === 200,
+  });
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
- add blue/green Helm deploy steps with automatic rollback across environments
- introduce k6 performance, OWASP ZAP, and Trivy scans that publish workflow artifacts
- document the new CI/CD stages and rollout strategy configuration points

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9e4cea56c8332bb62783d24aa1b81