### PR TITLE
Add infrastructure CDN, load balancers, backups, and cost monitoring

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -92,6 +92,13 @@ Le projet utilise une **architecture microservices** moderne :
 - **Base de Données** : PostgreSQL pour la persistance des données
 - **Cache** : Redis pour l'optimisation des performances
 
+### Renforcements d'Infrastructure Cloud
+
+- **CDN pour assets statiques** : Bucket S3 privé exposé via CloudFront avec prise en charge des domaines personnalisés.
+- **Load balancers partagés** : ALB (HTTP/HTTPS) et NLB (TCP) pré-provisionnés pour les charges ne passant pas par l'ingress Kubernetes.
+- **Sauvegardes automatisées** : Plan AWS Backup quotidien couvrant le cluster Aurora PostgreSQL avec rétention ajustable.
+- **Suivi des coûts** : Budget AWS mensuel envoyant des alertes aux équipes plateforme et finance.
+
 ### Structure des Repositories
 
 | Repository | Description | État |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ The project uses a modern **microservices architecture**:
 - **Database**: PostgreSQL for data persistence
 - **Cache**: Redis for performance optimization
 
+### Cloud Infrastructure Enhancements
+
+- **Static assets CDN**: Private S3 bucket fronted by CloudFront with optional custom domains.
+- **Shared load balancers**: Pre-provisioned ALB (HTTP/HTTPS) and NLB (TCP) endpoints for workloads that cannot rely on the ingress controller.
+- **Automated backups**: Daily AWS Backup plan covering the Aurora PostgreSQL cluster with configurable retention.
+- **Cost monitoring**: Monthly AWS Budget notifications to alert the platform team and finance stakeholders.
+
 ### Repository Structure
 
 | Repository | Description | Status |

--- a/docs/cloud-operations.md
+++ b/docs/cloud-operations.md
@@ -1,0 +1,70 @@
+# Cloud Operations Playbook
+
+This document captures the operational procedures for the managed AWS infrastructure supporting Meetinity. It complements the infrastructure-as-code definition located in `infra/terraform` and outlines how the new CDN, load balancers, backup policies, and cost controls are run in production.
+
+## Static Assets CDN
+
+The Terraform stack provisions an S3 bucket secured behind an Amazon CloudFront distribution. When enabled via the `static_assets` variable set, the module creates:
+
+- A private S3 bucket dedicated to immutable static assets.
+- A CloudFront distribution with HTTPS enforced, compression enabled, and an optional ACM certificate for custom domains.
+- Access controls that restrict origin access to the CloudFront identity.
+
+**Operational guidance:**
+
+1. Upload immutable front-end bundles or media assets to the bucket output in `static_assets_bucket_name`.
+2. Invalidate cached objects after deployments with:
+   ```bash
+   aws cloudfront create-invalidation \
+     --distribution-id $(terraform output -raw static_assets_distribution_id) \
+     --paths '/*'
+   ```
+3. Integrate the distribution hostname (`static_assets_cdn_domain`) with DNS by creating the appropriate CNAME/ALIAS records.
+4. Enable access logs by providing a logging bucket in `static_assets.logging_bucket`.
+
+## Shared Load Balancers
+
+Two shared load balancers are created to front workloads that sit outside Kubernetes ingress controllers:
+
+- **Application Load Balancer (ALB):** Internet-facing by default, with HTTP → HTTPS redirection when an ACM certificate is provided. Traffic is forwarded to an IP-based target group for integration with services running on EKS or EC2. The DNS name is exported as `shared_alb_dns_name`.
+- **Network Load Balancer (NLB):** Internal by default, exposing a TCP listener for latency-sensitive services (e.g. gRPC or MQTT). The DNS name is exported as `shared_nlb_dns_name`.
+
+**Operational guidance:**
+
+- Register Kubernetes services through the AWS Load Balancer Controller or attach IP targets manually to the published target group ARNs when required.
+- Update security policies for the ALB by adding rules to the security group (`${environment}-shared-alb-sg`).
+- Use the DNS names directly in Route 53 records or private DNS zones.
+
+## Backup and Recovery
+
+AWS Backup is configured to orchestrate daily snapshots for the Aurora PostgreSQL cluster and any additional ARNs passed in `backup_config.additional_resource_arns`.
+
+**Daily job:**
+
+- Scheduled with the expression `cron(0 3 * * ? *)` (03:00 UTC).
+- Snapshots are retained for 35 days by default; adjust with `backup_config.delete_after`.
+
+**Disaster recovery procedure:**
+
+1. Identify the most recent healthy recovery point in the AWS Backup console for the `aws_backup_vault_arn` output.
+2. Start a restore job targeting a new cluster or the existing cluster after isolating workloads.
+3. Once restored, update connection strings in Kubernetes secrets using `infra/scripts/deploy.sh` to repoint to the new endpoint.
+4. Run application smoke tests and, when stable, decommission the compromised cluster.
+
+Document any restore activities in the incident log and review retention requirements quarterly.
+
+## Cost Monitoring
+
+Cost governance leverages AWS Budgets. When `cost_monitoring.enabled` is true, Terraform creates a monthly budget with notification emails defined in `cost_monitoring.notification_emails`.
+
+**Operational guidance:**
+
+- Subscribe finance and platform leads to the budget notifications.
+- Review cost and usage trends weekly in AWS Cost Explorer, applying the same cost allocation tags defined in Terraform (`Environment`, `Project`).
+- Adjust the monthly limit (`cost_monitoring.budget_limit`) in environment-specific `.tfvars` files as the footprint grows.
+- Track anomalies from Cost Explorer within the same budget view to correlate spikes with deployments.
+
+## Runbook Updates
+
+- Re-run `infra/scripts/deploy.sh <env>` after modifying any of the above modules to ensure outputs and Kubernetes secrets stay in sync.
+- Store validated recovery steps and test results alongside this document to maintain an auditable history.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -8,6 +8,10 @@ This Terraform configuration bootstraps the AWS infrastructure required to run t
 - **EKS module** – Provisions an EKS control plane, managed node group, core add-ons (VPC CNI, CoreDNS, kube-proxy, EBS CSI), and IAM roles for administrators and CSI drivers.
 - **Helm releases** – Installs cert-manager (with a default self-signed issuer) and the NGINX ingress controller, wiring a default TLS certificate for new ingresses.
 - **Kubernetes namespaces & storage classes** – Pre-creates logical namespaces for monitoring/security, the ingress and cert-manager system namespaces, and a default gp3 storage class backed by the AWS EBS CSI driver.
+- **Static assets CDN** – Optional S3 bucket plus CloudFront distribution for hosting static web resources with HTTPS enforcement.
+- **Shared load balancers** – Application and Network Load Balancers ready to accept targets from EKS/EC2 workloads.
+- **AWS Backup plan** – Daily backups for the Aurora PostgreSQL cluster with configurable retention windows.
+- **Cost monitoring** – Monthly AWS Budget capable of notifying stakeholders when spend exceeds thresholds.
 
 ## Usage
 

--- a/infra/terraform/modules/backup/main.tf
+++ b/infra/terraform/modules/backup/main.tf
@@ -1,0 +1,82 @@
+locals {
+  enabled            = var.enabled
+  vault_name         = local.enabled ? coalesce(var.vault_name, "${var.environment}-backup-vault") : null
+  plan_name          = local.enabled ? coalesce(var.plan_name, "${var.environment}-daily-backup") : null
+  selection_name     = local.enabled ? "${var.environment}-backup-selection" : null
+  lifecycle_required = var.cold_storage_after > 0 || var.delete_after > 0
+}
+
+resource "aws_backup_vault" "this" {
+  count = local.enabled ? 1 : 0
+
+  name        = local.vault_name
+  kms_key_arn = null
+  tags        = merge(var.tags, { Name = local.vault_name })
+}
+
+resource "aws_backup_plan" "this" {
+  count = local.enabled ? 1 : 0
+
+  name = local.plan_name
+
+  rule {
+    rule_name         = "${local.plan_name}-rule"
+    target_vault_name = aws_backup_vault.this[0].name
+    schedule          = var.schedule_expression
+    start_window      = var.start_window
+    completion_window = var.completion_window
+
+    dynamic "lifecycle" {
+      for_each = local.lifecycle_required ? [1] : []
+
+      content {
+        cold_storage_after = var.cold_storage_after > 0 ? var.cold_storage_after : null
+        delete_after       = var.delete_after > 0 ? var.delete_after : null
+      }
+    }
+  }
+
+  tags = merge(var.tags, { Name = local.plan_name })
+}
+
+resource "aws_iam_role" "backup" {
+  count = local.enabled ? 1 : 0
+
+  name = "${var.environment}-aws-backup-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "backup.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  count      = local.enabled ? 1 : 0
+  role       = aws_iam_role.backup[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_iam_role_policy_attachment" "restore" {
+  count      = local.enabled ? 1 : 0
+  role       = aws_iam_role.backup[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}
+
+locals {
+  filtered_resource_arns = [for arn in var.resource_arns : arn if arn != null && arn != ""]
+}
+
+resource "aws_backup_selection" "this" {
+  count = local.enabled && length(local.filtered_resource_arns) > 0 ? 1 : 0
+
+  iam_role_arn = aws_iam_role.backup[0].arn
+  name         = local.selection_name
+  plan_id      = aws_backup_plan.this[0].id
+  resources    = local.filtered_resource_arns
+}

--- a/infra/terraform/modules/backup/outputs.tf
+++ b/infra/terraform/modules/backup/outputs.tf
@@ -1,0 +1,14 @@
+output "vault_arn" {
+  description = "ARN of the AWS Backup vault."
+  value       = try(aws_backup_vault.this[0].arn, null)
+}
+
+output "plan_arn" {
+  description = "ARN of the AWS Backup plan."
+  value       = try(aws_backup_plan.this[0].arn, null)
+}
+
+output "selection_id" {
+  description = "Identifier of the AWS Backup selection."
+  value       = try(aws_backup_selection.this[0].id, null)
+}

--- a/infra/terraform/modules/backup/variables.tf
+++ b/infra/terraform/modules/backup/variables.tf
@@ -1,0 +1,63 @@
+variable "enabled" {
+  description = "Whether to enable the AWS Backup plan."
+  type        = bool
+}
+
+variable "environment" {
+  description = "Environment identifier used for naming."
+  type        = string
+}
+
+variable "vault_name" {
+  description = "Optional custom name for the backup vault."
+  type        = string
+  default     = null
+}
+
+variable "plan_name" {
+  description = "Optional custom name for the backup plan."
+  type        = string
+  default     = null
+}
+
+variable "schedule_expression" {
+  description = "Cron expression defining when backups are created."
+  type        = string
+  default     = "cron(0 3 * * ? *)"
+}
+
+variable "start_window" {
+  description = "The amount of time in minutes before a backup job is considered late."
+  type        = number
+  default     = 60
+}
+
+variable "completion_window" {
+  description = "The amount of time in minutes AWS Backup attempts a backup before canceling the job."
+  type        = number
+  default     = 360
+}
+
+variable "cold_storage_after" {
+  description = "Number of days before moving recovery points to cold storage."
+  type        = number
+  default     = 0
+}
+
+variable "delete_after" {
+  description = "Number of days before deleting recovery points."
+  type        = number
+  default     = 35
+}
+
+variable "resource_arns" {
+  description = "List of resource ARNs to include in the backup selection."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/cdn/main.tf
+++ b/infra/terraform/modules/cdn/main.tf
@@ -1,0 +1,142 @@
+locals {
+  enabled         = var.enabled
+  bucket_base     = var.bucket_name != null ? var.bucket_name : "${var.environment}-static-assets"
+  origin_id       = "s3-static-assets"
+  viewer_protocol = "redirect-to-https"
+}
+
+resource "random_id" "bucket_suffix" {
+  count       = local.enabled && var.bucket_name == null ? 1 : 0
+  byte_length = 4
+}
+
+locals {
+  bucket_name = local.enabled ? (var.bucket_name != null ? var.bucket_name : "${local.bucket_base}-${lower(random_id.bucket_suffix[0].hex)}") : null
+}
+
+resource "aws_s3_bucket" "static_assets" {
+  count  = local.enabled ? 1 : 0
+  bucket = local.bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "static_assets" {
+  count  = local.enabled ? 1 : 0
+  bucket = aws_s3_bucket.static_assets[0].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "static_assets" {
+  count  = local.enabled ? 1 : 0
+  bucket = aws_s3_bucket.static_assets[0].bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "static_assets" {
+  count                   = local.enabled ? 1 : 0
+  bucket                  = aws_s3_bucket.static_assets[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_identity" "this" {
+  count   = local.enabled ? 1 : 0
+  comment = "Access identity for ${local.bucket_name}"
+}
+
+data "aws_iam_policy_document" "static_assets" {
+  count = local.enabled ? 1 : 0
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.static_assets[0].arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.this[0].iam_arn]
+    }
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.static_assets[0].arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.this[0].iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "static_assets" {
+  count  = local.enabled ? 1 : 0
+  bucket = aws_s3_bucket.static_assets[0].id
+  policy = data.aws_iam_policy_document.static_assets[0].json
+}
+
+resource "aws_cloudfront_distribution" "static_assets" {
+  count               = local.enabled ? 1 : 0
+  enabled             = true
+  comment             = "Static assets distribution for ${var.environment}"
+  price_class         = var.price_class
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  tags                = var.tags
+
+  origin {
+    domain_name = aws_s3_bucket.static_assets[0].bucket_regional_domain_name
+    origin_id   = local.origin_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.this[0].cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.origin_id
+    viewer_protocol_policy = local.viewer_protocol
+    compress               = var.compress_objects
+
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    min_ttl         = var.min_ttl
+    default_ttl     = var.default_ttl
+    max_ttl         = var.max_ttl
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = var.acm_certificate_arn
+    cloudfront_default_certificate = var.acm_certificate_arn == null
+    minimum_protocol_version       = var.acm_certificate_arn == null ? "TLSv1" : var.minimum_protocol_version
+    ssl_support_method             = var.acm_certificate_arn == null ? null : "sni-only"
+  }
+
+  aliases = var.domain_names
+
+  dynamic "logging_config" {
+    for_each = var.logging_bucket != null ? [var.logging_bucket] : []
+
+    content {
+      include_cookies = false
+      bucket          = logging_config.value
+      prefix          = "cloudfront/${var.environment}"
+    }
+  }
+}

--- a/infra/terraform/modules/cdn/outputs.tf
+++ b/infra/terraform/modules/cdn/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_name" {
+  description = "Name of the S3 bucket storing static assets."
+  value       = try(aws_s3_bucket.static_assets[0].bucket, null)
+}
+
+output "distribution_id" {
+  description = "Identifier of the CloudFront distribution."
+  value       = try(aws_cloudfront_distribution.static_assets[0].id, null)
+}
+
+output "distribution_domain_name" {
+  description = "Domain name assigned to the CloudFront distribution."
+  value       = try(aws_cloudfront_distribution.static_assets[0].domain_name, null)
+}

--- a/infra/terraform/modules/cdn/variables.tf
+++ b/infra/terraform/modules/cdn/variables.tf
@@ -1,0 +1,75 @@
+variable "enabled" {
+  description = "Whether to provision the static assets CDN."
+  type        = bool
+}
+
+variable "environment" {
+  description = "Environment name used to derive resource names."
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "Optional custom name for the S3 bucket storing static assets."
+  type        = string
+  default     = null
+}
+
+variable "domain_names" {
+  description = "Optional list of DNS aliases for the CloudFront distribution."
+  type        = list(string)
+  default     = []
+}
+
+variable "price_class" {
+  description = "CloudFront price class controlling the edge locations used."
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "default_ttl" {
+  description = "Default TTL for cached objects in seconds."
+  type        = number
+  default     = 3600
+}
+
+variable "max_ttl" {
+  description = "Maximum TTL for cached objects in seconds."
+  type        = number
+  default     = 86400
+}
+
+variable "min_ttl" {
+  description = "Minimum TTL for cached objects in seconds."
+  type        = number
+  default     = 0
+}
+
+variable "compress_objects" {
+  description = "Whether to enable CloudFront compression for cached objects."
+  type        = bool
+  default     = true
+}
+
+variable "acm_certificate_arn" {
+  description = "Optional ACM certificate ARN for custom HTTPS domains."
+  type        = string
+  default     = null
+}
+
+variable "logging_bucket" {
+  description = "Optional S3 bucket where CloudFront access logs will be delivered."
+  type        = string
+  default     = null
+}
+
+variable "minimum_protocol_version" {
+  description = "Minimum supported TLS protocol version for viewer connections."
+  type        = string
+  default     = "TLSv1.2_2021"
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/cost_monitoring/main.tf
+++ b/infra/terraform/modules/cost_monitoring/main.tf
@@ -1,0 +1,34 @@
+locals {
+  enabled      = var.enabled
+  budget_limit = var.budget_limit
+  start_date   = "${formatdate("YYYY-MM-01", timestamp())}_00:00"
+}
+
+resource "aws_budgets_budget" "monthly" {
+  count = local.enabled && local.budget_limit != null ? 1 : 0
+
+  name              = "platform-spend"
+  budget_type       = var.budget_type
+  limit_amount      = tostring(local.budget_limit)
+  limit_unit        = var.limit_unit
+  time_unit         = var.time_unit
+  time_period_start = local.start_date
+
+  dynamic "notification" {
+    for_each = var.notification_emails
+
+    content {
+      comparison_operator = "GREATER_THAN"
+      threshold           = var.threshold_percent
+      threshold_type      = "PERCENTAGE"
+      notification_type   = "ACTUAL"
+
+      subscriber {
+        subscription_type = "EMAIL"
+        address           = notification.value
+      }
+    }
+  }
+
+  tags = var.tags
+}

--- a/infra/terraform/modules/cost_monitoring/outputs.tf
+++ b/infra/terraform/modules/cost_monitoring/outputs.tf
@@ -1,0 +1,4 @@
+output "budget_arn" {
+  description = "ARN of the AWS Budget used for cost monitoring."
+  value       = try(aws_budgets_budget.monthly[0].arn, null)
+}

--- a/infra/terraform/modules/cost_monitoring/variables.tf
+++ b/infra/terraform/modules/cost_monitoring/variables.tf
@@ -1,0 +1,46 @@
+variable "enabled" {
+  description = "Whether to enable cost monitoring resources."
+  type        = bool
+}
+
+variable "budget_limit" {
+  description = "Monthly cost budget limit in the billing currency."
+  type        = number
+  default     = null
+}
+
+variable "time_unit" {
+  description = "Time unit for the AWS Budget (e.g. MONTHLY, QUARTERLY)."
+  type        = string
+  default     = "MONTHLY"
+}
+
+variable "budget_type" {
+  description = "Type of budget to create (e.g. COST, USAGE)."
+  type        = string
+  default     = "COST"
+}
+
+variable "limit_unit" {
+  description = "Currency unit used for the budget limit."
+  type        = string
+  default     = "USD"
+}
+
+variable "threshold_percent" {
+  description = "Percentage of the budget that triggers notifications."
+  type        = number
+  default     = 80
+}
+
+variable "notification_emails" {
+  description = "List of email addresses to notify when the threshold is reached."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags to apply to cost monitoring resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/load_balancers/main.tf
+++ b/infra/terraform/modules/load_balancers/main.tf
@@ -1,0 +1,168 @@
+locals {
+  alb_enabled = try(var.alb_config.enabled, false)
+  nlb_enabled = try(var.nlb_config.enabled, false)
+
+  alb_name = local.alb_enabled ? coalesce(try(var.alb_config.name, null), "${var.environment}-shared-alb") : null
+  nlb_name = local.nlb_enabled ? coalesce(try(var.nlb_config.name, null), "${var.environment}-shared-nlb") : null
+
+  alb_subnets = local.alb_enabled ? coalesce(try(var.alb_config.subnets, []), var.public_subnet_ids) : []
+  nlb_subnets = local.nlb_enabled ? coalesce(try(var.nlb_config.subnets, []), var.private_subnet_ids) : []
+
+  alb_http_port  = try(var.alb_config.http_port, 80)
+  alb_https_port = try(var.alb_config.https_port, 443)
+
+  alb_cert_arn    = try(var.alb_config.certificate_arn, null)
+  alb_health_path = try(var.alb_config.health_check_path, "/healthz")
+
+  nlb_tcp_port = try(var.nlb_config.tcp_port, 443)
+}
+
+resource "aws_security_group" "alb" {
+  count  = local.alb_enabled ? 1 : 0
+  name   = "${local.alb_name}-sg"
+  vpc_id = var.vpc_id
+  tags   = merge(var.tags, { Name = "${local.alb_name}-sg" })
+
+  ingress {
+    description = "Allow HTTP"
+    from_port   = local.alb_http_port
+    to_port     = local.alb_http_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  dynamic "ingress" {
+    for_each = local.alb_cert_arn != null ? [1] : []
+
+    content {
+      description = "Allow HTTPS"
+      from_port   = local.alb_https_port
+      to_port     = local.alb_https_port
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lb" "alb" {
+  count                      = local.alb_enabled ? 1 : 0
+  name                       = substr(local.alb_name, 0, 32)
+  load_balancer_type         = "application"
+  security_groups            = concat(local.alb_enabled ? [aws_security_group.alb[0].id] : [], try(var.alb_config.security_group_ids, []))
+  subnets                    = local.alb_subnets
+  idle_timeout               = try(var.alb_config.idle_timeout, 60)
+  internal                   = try(var.alb_config.internal, false)
+  enable_deletion_protection = false
+  tags                       = merge(var.tags, { Name = local.alb_name })
+}
+
+resource "aws_lb_target_group" "alb_http" {
+  count    = local.alb_enabled ? 1 : 0
+  name     = substr("${local.alb_name}-tg", 0, 32)
+  port     = local.alb_http_port
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = local.alb_health_path
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-399"
+  }
+
+  tags = merge(var.tags, { Name = "${local.alb_name}-tg" })
+}
+
+resource "aws_lb_listener" "alb_http" {
+  count             = local.alb_enabled ? 1 : 0
+  load_balancer_arn = aws_lb.alb[0].arn
+  port              = local.alb_http_port
+  protocol          = "HTTP"
+
+  dynamic "default_action" {
+    for_each = local.alb_cert_arn != null ? [1] : []
+
+    content {
+      type = "redirect"
+      redirect {
+        status_code = "HTTP_301"
+        port        = tostring(local.alb_https_port)
+        protocol    = "HTTPS"
+      }
+    }
+  }
+
+  dynamic "default_action" {
+    for_each = local.alb_cert_arn == null ? [1] : []
+
+    content {
+      type             = "forward"
+      target_group_arn = aws_lb_target_group.alb_http[0].arn
+    }
+  }
+}
+
+resource "aws_lb_listener" "alb_https" {
+  count             = local.alb_enabled && local.alb_cert_arn != null ? 1 : 0
+  load_balancer_arn = aws_lb.alb[0].arn
+  port              = local.alb_https_port
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = local.alb_cert_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.alb_http[0].arn
+  }
+}
+
+resource "aws_lb" "nlb" {
+  count                      = local.nlb_enabled ? 1 : 0
+  name                       = substr(local.nlb_name, 0, 32)
+  load_balancer_type         = "network"
+  internal                   = try(var.nlb_config.internal, true)
+  subnets                    = local.nlb_subnets
+  enable_deletion_protection = false
+  enable_cross_zone_load_balancing = try(var.nlb_config.cross_zone, true)
+  tags = merge(var.tags, { Name = local.nlb_name })
+}
+
+resource "aws_lb_target_group" "nlb_tcp" {
+  count    = local.nlb_enabled ? 1 : 0
+  name     = substr("${local.nlb_name}-tg", 0, 32)
+  port     = local.nlb_tcp_port
+  protocol = "TCP"
+  vpc_id   = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    protocol            = try(var.nlb_config.health_check_protocol, "TCP")
+    port                = try(var.nlb_config.health_check_port, "traffic-port")
+    interval            = try(var.nlb_config.health_check_interval, 30)
+    healthy_threshold   = try(var.nlb_config.healthy_threshold, 3)
+    unhealthy_threshold = try(var.nlb_config.unhealthy_threshold, 3)
+  }
+
+  tags = merge(var.tags, { Name = "${local.nlb_name}-tg" })
+}
+
+resource "aws_lb_listener" "nlb_tcp" {
+  count             = local.nlb_enabled ? 1 : 0
+  load_balancer_arn = aws_lb.nlb[0].arn
+  port              = local.nlb_tcp_port
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.nlb_tcp[0].arn
+  }
+}

--- a/infra/terraform/modules/load_balancers/outputs.tf
+++ b/infra/terraform/modules/load_balancers/outputs.tf
@@ -1,0 +1,29 @@
+output "alb_arn" {
+  description = "ARN of the shared Application Load Balancer."
+  value       = try(aws_lb.alb[0].arn, null)
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the shared Application Load Balancer."
+  value       = try(aws_lb.alb[0].dns_name, null)
+}
+
+output "alb_target_group_arn" {
+  description = "ARN of the ALB target group forwarding HTTP traffic."
+  value       = try(aws_lb_target_group.alb_http[0].arn, null)
+}
+
+output "nlb_arn" {
+  description = "ARN of the shared Network Load Balancer."
+  value       = try(aws_lb.nlb[0].arn, null)
+}
+
+output "nlb_dns_name" {
+  description = "DNS name of the shared Network Load Balancer."
+  value       = try(aws_lb.nlb[0].dns_name, null)
+}
+
+output "nlb_target_group_arn" {
+  description = "ARN of the NLB target group forwarding TCP traffic."
+  value       = try(aws_lb_target_group.nlb_tcp[0].arn, null)
+}

--- a/infra/terraform/modules/load_balancers/variables.tf
+++ b/infra/terraform/modules/load_balancers/variables.tf
@@ -1,0 +1,64 @@
+variable "vpc_id" {
+  description = "Identifier of the VPC where load balancers will be created."
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "List of public subnet IDs available for load balancers."
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs available for internal load balancers."
+  type        = list(string)
+}
+
+variable "environment" {
+  description = "Environment name used for tagging and naming."
+  type        = string
+}
+
+variable "alb_config" {
+  description = "Configuration for the shared Application Load Balancer."
+  type = object({
+    enabled            = bool
+    name               = optional(string)
+    internal           = optional(bool, false)
+    idle_timeout       = optional(number, 60)
+    certificate_arn    = optional(string)
+    subnets            = optional(list(string))
+    security_group_ids = optional(list(string), [])
+    http_port          = optional(number, 80)
+    https_port         = optional(number, 443)
+    health_check_path  = optional(string, "/healthz")
+  })
+  default = {
+    enabled = false
+  }
+}
+
+variable "nlb_config" {
+  description = "Configuration for the shared Network Load Balancer."
+  type = object({
+    enabled                = bool
+    name                   = optional(string)
+    internal               = optional(bool, true)
+    cross_zone             = optional(bool, true)
+    subnets                = optional(list(string))
+    tcp_port               = optional(number, 443)
+    health_check_protocol  = optional(string, "TCP")
+    health_check_port      = optional(number)
+    health_check_interval  = optional(number, 30)
+    healthy_threshold      = optional(number, 3)
+    unhealthy_threshold    = optional(number, 3)
+  })
+  default = {
+    enabled = false
+  }
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/rds/outputs.tf
+++ b/infra/terraform/modules/rds/outputs.tf
@@ -33,3 +33,13 @@ output "security_group_id" {
   description = "Security group protecting the database cluster."
   value       = aws_security_group.this.id
 }
+
+output "cluster_arn" {
+  description = "ARN of the Aurora PostgreSQL cluster."
+  value       = aws_rds_cluster.this.arn
+}
+
+output "cluster_id" {
+  description = "Identifier of the Aurora PostgreSQL cluster."
+  value       = aws_rds_cluster.this.id
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -89,3 +89,38 @@ output "redis_auth_token" {
   value       = module.redis.auth_token
   sensitive   = true
 }
+
+output "static_assets_bucket_name" {
+  description = "Name of the S3 bucket hosting static assets."
+  value       = module.static_assets.bucket_name
+}
+
+output "static_assets_cdn_domain" {
+  description = "Domain name of the CloudFront distribution serving static assets."
+  value       = module.static_assets.distribution_domain_name
+}
+
+output "static_assets_distribution_id" {
+  description = "Identifier of the CloudFront distribution serving static assets."
+  value       = module.static_assets.distribution_id
+}
+
+output "shared_alb_dns_name" {
+  description = "DNS name of the shared Application Load Balancer."
+  value       = module.load_balancers.alb_dns_name
+}
+
+output "shared_nlb_dns_name" {
+  description = "DNS name of the shared Network Load Balancer."
+  value       = module.load_balancers.nlb_dns_name
+}
+
+output "aws_backup_vault_arn" {
+  description = "ARN of the AWS Backup vault protecting stateful services."
+  value       = module.backup.vault_arn
+}
+
+output "cost_budget_arn" {
+  description = "ARN of the AWS Budgets resource tracking monthly spend."
+  value       = module.cost_monitoring.budget_arn
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -227,3 +227,96 @@ variable "shield_protection" {
     health_check_ids = []
   }
 }
+
+variable "static_assets" {
+  description = "Configuration for the static assets CDN."
+  type = object({
+    enabled               = bool
+    bucket_name           = optional(string)
+    domain_names          = optional(list(string), [])
+    price_class           = optional(string, "PriceClass_100")
+    default_ttl_seconds   = optional(number, 3600)
+    max_ttl_seconds       = optional(number, 86400)
+    min_ttl_seconds       = optional(number, 0)
+    compress              = optional(bool, true)
+    acm_certificate_arn   = optional(string)
+    logging_bucket        = optional(string)
+    minimum_protocol      = optional(string, "TLSv1.2_2021")
+  })
+  default = {
+    enabled = false
+  }
+}
+
+variable "alb_config" {
+  description = "Shared Application Load Balancer configuration."
+  type = object({
+    enabled            = bool
+    name               = optional(string)
+    internal           = optional(bool, false)
+    idle_timeout       = optional(number, 60)
+    certificate_arn    = optional(string)
+    subnets            = optional(list(string))
+    security_group_ids = optional(list(string), [])
+    http_port          = optional(number, 80)
+    https_port         = optional(number, 443)
+    health_check_path  = optional(string, "/healthz")
+  })
+  default = {
+    enabled = false
+  }
+}
+
+variable "nlb_config" {
+  description = "Shared Network Load Balancer configuration."
+  type = object({
+    enabled               = bool
+    name                  = optional(string)
+    internal              = optional(bool, true)
+    cross_zone            = optional(bool, true)
+    subnets               = optional(list(string))
+    tcp_port              = optional(number, 443)
+    health_check_protocol = optional(string, "TCP")
+    health_check_port     = optional(number)
+    health_check_interval = optional(number, 30)
+    healthy_threshold     = optional(number, 3)
+    unhealthy_threshold   = optional(number, 3)
+  })
+  default = {
+    enabled = false
+  }
+}
+
+variable "backup_config" {
+  description = "Configuration for the AWS Backup plan."
+  type = object({
+    enabled                = bool
+    vault_name             = optional(string)
+    plan_name              = optional(string)
+    schedule_expression    = optional(string, "cron(0 3 * * ? *)")
+    start_window_minutes   = optional(number, 60)
+    completion_window      = optional(number, 360)
+    cold_storage_after     = optional(number, 0)
+    delete_after           = optional(number, 35)
+    additional_resource_arns = optional(list(string), [])
+  })
+  default = {
+    enabled = false
+  }
+}
+
+variable "cost_monitoring" {
+  description = "Configuration for AWS cost monitoring."
+  type = object({
+    enabled             = bool
+    budget_limit        = optional(number)
+    budget_type         = optional(string, "COST")
+    time_unit           = optional(string, "MONTHLY")
+    limit_unit          = optional(string, "USD")
+    threshold_percent   = optional(number, 80)
+    notification_emails = optional(list(string), [])
+  })
+  default = {
+    enabled = false
+  }
+}


### PR DESCRIPTION
## Summary
- add a configurable static assets CDN, shared load balancers, and supporting Terraform modules
- provision AWS Backup and cost monitoring resources with new outputs consumed by the deployment tooling
- document runbooks and update READMEs to highlight the new operational components

## Testing
- terraform fmt -recursive *(fails: terraform: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e643bcac8332a8bfb1eb0d190fe1