### PR TITLE
Add event and matching upstream support to API gateway

### DIFF
--- a/services/api-gateway/tests/test_api_management.py
+++ b/services/api-gateway/tests/test_api_management.py
@@ -13,9 +13,13 @@ from src.app import create_app  # noqa: E402
 
 def _configure_base_env(monkeypatch):
     monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("EVENT_SERVICE_URL", "http://events")
+    monkeypatch.setenv("MATCHING_SERVICE_URL", "http://matching")
     monkeypatch.setenv("CORS_ORIGINS", "")
     monkeypatch.setenv("JWT_SECRET", "secret")
     monkeypatch.setenv("RATE_LIMIT_AUTH", "20/minute")
+    monkeypatch.setenv("RATE_LIMIT_EVENTS", "20/minute")
+    monkeypatch.setenv("RATE_LIMIT_MATCHING", "20/minute")
     monkeypatch.setenv("RESILIENCE_BACKOFF_FACTOR", "0")
 
 

--- a/services/api-gateway/tests/test_caching.py
+++ b/services/api-gateway/tests/test_caching.py
@@ -11,8 +11,12 @@ from src.app import create_app
 @pytest.fixture
 def app(monkeypatch):
     monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("EVENT_SERVICE_URL", "http://events")
+    monkeypatch.setenv("MATCHING_SERVICE_URL", "http://matching")
     monkeypatch.setenv("JWT_SECRET", "secret")
     monkeypatch.setenv("RATE_LIMIT_AUTH", "10/minute")
+    monkeypatch.setenv("RATE_LIMIT_EVENTS", "10/minute")
+    monkeypatch.setenv("RATE_LIMIT_MATCHING", "10/minute")
     monkeypatch.setenv("RESILIENCE_BACKOFF_FACTOR", "0")
     monkeypatch.setenv("CACHE_DEFAULT_TTL", "60")
     app = create_app()

--- a/services/api-gateway/tests/test_observability.py
+++ b/services/api-gateway/tests/test_observability.py
@@ -31,6 +31,8 @@ def _patch_proxy_session(monkeypatch, handler):
 
 def test_metrics_endpoint_records_requests(monkeypatch):
     monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("EVENT_SERVICE_URL", "http://events")
+    monkeypatch.setenv("MATCHING_SERVICE_URL", "http://matching")
     app = create_app()
 
     client = app.test_client()
@@ -50,6 +52,8 @@ def test_proxy_tracing_creates_spans(monkeypatch):
     exporter = InMemorySpanExporter()
 
     monkeypatch.setenv("USER_SERVICE_URL", "http://upstream")
+    monkeypatch.setenv("EVENT_SERVICE_URL", "http://events")
+    monkeypatch.setenv("MATCHING_SERVICE_URL", "http://matching")
     monkeypatch.setenv("LOG_AGGREGATORS", "")
 
     monkeypatch.setattr(app_module, "configure_tracing", lambda app: None)


### PR DESCRIPTION
## Summary
- add proxy routes for the event and matching APIs with JWT and rate limiting
- extend service configuration, registry, and health reporting to cover the new upstreams
- update test coverage for routing and discovery of the additional services

## Testing
- pytest services/api-gateway/tests *(fails: missing dependencies requests, jwt, opentelemetry, openapi_core)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f62fa8a4833281a79c5781033e05