### PR TITLE
feat(matching): migrate storage to PostgreSQL and add ingestion API

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -167,10 +167,10 @@ services:
       FLASK_RUN_HOST: 0.0.0.0
       FLASK_RUN_PORT: 8080
       FLASK_DEBUG: "1"
-      DATABASE_URI: sqlite:////tmp/matching.db
+      DATABASE_URI: postgresql+psycopg://${POSTGRES_USER:-meetinity}:${POSTGRES_PASSWORD:-meetinity}@postgres:5432/${POSTGRES_DB:-meetinity}?options=-csearch_path%3Dmatching
       PYTHONUNBUFFERED: "1"
     command: >
-      sh -c "flask run --debug --host=0.0.0.0 --port 8080"
+      sh -c "alembic upgrade head && flask run --debug --host=0.0.0.0 --port 8080"
     volumes:
       - ./services/matching-service:/app
     networks:

--- a/scripts/dev/seed.sh
+++ b/scripts/dev/seed.sh
@@ -13,7 +13,7 @@ else
 fi
 
 # Exécute les migrations des services dépendants pour garantir que les tables existent.
-for service in user-service event-service; do
+for service in user-service event-service matching-service; do
   echo "[seed] Application des migrations pour ${service}"
   "${COMPOSE_CMD[@]}" exec "${service}" alembic upgrade head >/dev/null
 done

--- a/scripts/dev/sql/seed.sql
+++ b/scripts/dev/sql/seed.sql
@@ -229,6 +229,168 @@ ON CONFLICT (id) DO UPDATE SET
     trust_score = EXCLUDED.trust_score,
     updated_at = NOW();
 
+\echo 'Chargement des profils de matching'
+INSERT INTO matching.users (
+    id, email, full_name, title, company, bio, preferences, is_active, created_at, updated_at
+)
+VALUES
+    (
+        9000,
+        'alice.martin@example.com',
+        'Alice Martin',
+        'Lead PM',
+        'Meetinity',
+        'Experte produit passionnée par les communautés SaaS.',
+        '[{"type":"skills","value":["product","leadership","ai"]},{"type":"objectives","value":["networking","mentorat"]}]'::jsonb,
+        TRUE,
+        timezone('UTC', now()) - INTERVAL '120 days',
+        timezone('UTC', now())
+    ),
+    (
+        9001,
+        'bruno.leroy@example.com',
+        'Bruno Leroy',
+        'Engineering Manager',
+        'Meetinity',
+        'Manager technique encadrant des équipes distribuées.',
+        '[{"type":"skills","value":["cloud","kafka","python"]},{"type":"connections","value":["product","devops"]}]'::jsonb,
+        TRUE,
+        timezone('UTC', now()) - INTERVAL '200 days',
+        timezone('UTC', now())
+    ),
+    (
+        9002,
+        'claire.dupont@example.com',
+        'Claire Dupont',
+        'UX Researcher',
+        'Freelance',
+        'Spécialiste de la recherche utilisateur et du design inclusif.',
+        '[{"type":"skills","value":["ux","recherche","facilitation"]},{"type":"objectives","value":["co-création","partage"]}]'::jsonb,
+        TRUE,
+        timezone('UTC', now()) - INTERVAL '90 days',
+        timezone('UTC', now())
+    )
+ON CONFLICT (id) DO UPDATE SET
+    email = EXCLUDED.email,
+    full_name = EXCLUDED.full_name,
+    title = EXCLUDED.title,
+    company = EXCLUDED.company,
+    bio = EXCLUDED.bio,
+    preferences = EXCLUDED.preferences,
+    is_active = EXCLUDED.is_active,
+    updated_at = timezone('UTC', now());
+
+SELECT setval('matching.users_id_seq', (SELECT MAX(id) FROM matching.users));
+
+INSERT INTO matching.swipes (id, user_id, target_id, action, created_at)
+VALUES
+    (
+        6000,
+        9000,
+        9001,
+        'like',
+        timezone('UTC', now()) - INTERVAL '2 days'
+    ),
+    (
+        6001,
+        9001,
+        9000,
+        'like',
+        timezone('UTC', now()) - INTERVAL '1 day'
+    ),
+    (
+        6002,
+        9002,
+        9000,
+        'pass',
+        timezone('UTC', now()) - INTERVAL '3 days'
+    )
+ON CONFLICT (id) DO UPDATE SET
+    user_id = EXCLUDED.user_id,
+    target_id = EXCLUDED.target_id,
+    action = EXCLUDED.action,
+    created_at = EXCLUDED.created_at;
+
+SELECT setval('matching.swipes_id_seq', (SELECT MAX(id) FROM matching.swipes));
+
+INSERT INTO matching.matches (id, user_id, matched_user_id, created_at)
+VALUES
+    (
+        7000,
+        9000,
+        9001,
+        timezone('UTC', now()) - INTERVAL '1 day'
+    ),
+    (
+        7001,
+        9001,
+        9000,
+        timezone('UTC', now()) - INTERVAL '1 day'
+    )
+ON CONFLICT (user_id, matched_user_id) DO UPDATE SET
+    created_at = EXCLUDED.created_at;
+
+SELECT setval('matching.matches_id_seq', (SELECT MAX(id) FROM matching.matches));
+
+INSERT INTO matching.match_scores (id, match_id, score, details, created_at)
+VALUES
+    (
+        7100,
+        7000,
+        87.5,
+        '{"common_interests":["product","meetups"]}'::jsonb,
+        timezone('UTC', now()) - INTERVAL '1 day'
+    ),
+    (
+        7101,
+        7001,
+        87.5,
+        '{"common_interests":["product","mentorat"]}'::jsonb,
+        timezone('UTC', now()) - INTERVAL '1 day'
+    )
+ON CONFLICT (match_id) DO UPDATE SET
+    score = EXCLUDED.score,
+    details = EXCLUDED.details,
+    created_at = EXCLUDED.created_at;
+
+SELECT setval('matching.match_scores_id_seq', (SELECT MAX(id) FROM matching.match_scores));
+
+INSERT INTO matching.swipe_events (id, swipe_id, event_type, user_id, target_id, action, score, payload, created_at)
+VALUES
+    (
+        8000,
+        6000,
+        'swipe',
+        9000,
+        9001,
+        'like',
+        87.5,
+        '{"is_match": true, "common_interests": ["product","meetups"]}'::jsonb,
+        timezone('UTC', now()) - INTERVAL '1 day'
+    ),
+    (
+        8001,
+        6002,
+        'swipe',
+        9002,
+        9000,
+        'pass',
+        NULL,
+        '{"notes": "Pas d'intérêt commun identifié"}'::jsonb,
+        timezone('UTC', now()) - INTERVAL '3 days'
+    )
+ON CONFLICT (id) DO UPDATE SET
+    swipe_id = EXCLUDED.swipe_id,
+    event_type = EXCLUDED.event_type,
+    user_id = EXCLUDED.user_id,
+    target_id = EXCLUDED.target_id,
+    action = EXCLUDED.action,
+    score = EXCLUDED.score,
+    payload = EXCLUDED.payload,
+    created_at = EXCLUDED.created_at;
+
+SELECT setval('matching.swipe_events_id_seq', (SELECT MAX(id) FROM matching.swipe_events));
+
 \echo 'Chargement des inscriptions'
 INSERT INTO registrations (
     id, event_id, attendee_email, attendee_name, status, check_in_token, qr_code_data

--- a/services/matching-service/alembic.ini
+++ b/services/matching-service/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = postgresql+psycopg://meetinity:meetinity@localhost:5432/meetinity?options=-csearch_path%3Dmatching
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/services/matching-service/alembic/env.py
+++ b/services/matching-service/alembic/env.py
@@ -1,0 +1,70 @@
+"""Alembic environment configuration for the matching service."""
+
+from __future__ import annotations
+
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from src.config import get_settings  # noqa: E402
+from src.storage.database import Base  # noqa: E402
+
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def _database_url() -> str:
+    return get_settings().database_uri
+
+
+def run_migrations_offline() -> None:
+    url = _database_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        include_schemas=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section) or {}
+    configuration["sqlalchemy.url"] = _database_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            include_schemas=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/matching-service/alembic/versions/202502170001_create_matching_tables.py
+++ b/services/matching-service/alembic/versions/202502170001_create_matching_tables.py
@@ -1,0 +1,95 @@
+"""Create initial schema for matching service."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "202502170001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+SCHEMA = "matching"
+
+
+def upgrade() -> None:
+    op.execute(sa.schema.CreateSchema(SCHEMA, if_not_exists=True))
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("email", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("full_name", sa.String(length=255), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("company", sa.String(length=255), nullable=True),
+        sa.Column("bio", sa.Text(), nullable=True),
+        sa.Column("preferences", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'[]'::jsonb")),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("timezone('UTC', now())")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("timezone('UTC', now())")),
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "swipes",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("target_id", sa.Integer(), nullable=False),
+        sa.Column("action", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("timezone('UTC', now())")),
+        sa.ForeignKeyConstraint(["user_id"], [f"{SCHEMA}.users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["target_id"], [f"{SCHEMA}.users.id"], ondelete="CASCADE"),
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "matches",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("matched_user_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("timezone('UTC', now())")),
+        sa.UniqueConstraint("user_id", "matched_user_id", name="uq_match"),
+        sa.ForeignKeyConstraint(["user_id"], [f"{SCHEMA}.users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["matched_user_id"], [f"{SCHEMA}.users.id"], ondelete="CASCADE"),
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "match_scores",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("match_id", sa.Integer(), nullable=False, unique=True),
+        sa.Column("score", sa.Float(), nullable=False),
+        sa.Column("details", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("timezone('UTC', now())")),
+        sa.ForeignKeyConstraint(["match_id"], [f"{SCHEMA}.matches.id"], ondelete="CASCADE"),
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "swipe_events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("swipe_id", sa.Integer(), nullable=True),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("target_id", sa.Integer(), nullable=False),
+        sa.Column("action", sa.String(length=16), nullable=False),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("timezone('UTC', now())")),
+        sa.ForeignKeyConstraint(["swipe_id"], [f"{SCHEMA}.swipes.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["user_id"], [f"{SCHEMA}.users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["target_id"], [f"{SCHEMA}.users.id"], ondelete="CASCADE"),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("swipe_events", schema=SCHEMA)
+    op.drop_table("match_scores", schema=SCHEMA)
+    op.drop_table("matches", schema=SCHEMA)
+    op.drop_table("swipes", schema=SCHEMA)
+    op.drop_table("users", schema=SCHEMA)
+    op.execute(sa.schema.DropSchema(SCHEMA, cascade=True))

--- a/services/matching-service/requirements.txt
+++ b/services/matching-service/requirements.txt
@@ -1,6 +1,10 @@
 Flask==3.0.0
 Flask-CORS==4.0.0
+SQLAlchemy==2.0.29
+alembic==1.13.2
+psycopg[binary]==3.1.18
 pytest==7.4.0
+testcontainers[postgres]==3.7.1
 flake8==6.0.0
 numpy==1.26.4
 scikit-learn==1.3.2

--- a/services/matching-service/src/storage/__init__.py
+++ b/services/matching-service/src/storage/__init__.py
@@ -5,14 +5,16 @@ from .database import (
     create_matches,
     create_swipe,
     create_user,
-    list_users,
     fetch_matches_for_user,
     fetch_swipe_events,
     get_user,
     has_mutual_like,
     init_db,
+    list_users,
     log_swipe_event,
     reset_database,
+    reset_engine,
+    upsert_user,
 )
 from .models import Match, MatchScore, Swipe, SwipeEvent, User
 
@@ -34,5 +36,7 @@ __all__ = [
     "init_db",
     "log_swipe_event",
     "reset_database",
+    "reset_engine",
+    "upsert_user",
 ]
 

--- a/services/matching-service/src/storage/database.py
+++ b/services/matching-service/src/storage/database.py
@@ -1,257 +1,357 @@
-"""Lightweight ORM-like layer backed by sqlite3."""
+"""SQLAlchemy-powered persistence layer for the matching service."""
 
 from __future__ import annotations
 
-import json
-import sqlite3
-import threading
 import time
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, List, Optional
+from typing import Any, Dict, Iterable, Iterator, List, Optional
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    select,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    Session,
+    aliased,
+    mapped_column,
+    relationship,
+    sessionmaker,
+)
 
 from src.config import get_settings
 
 from .models import Swipe, SwipeEvent, User
 
-
-_CONNECTION: Optional[sqlite3.Connection] = None
-_LOCK = threading.Lock()
+SCHEMA_NAME = "matching"
 
 
-def _ensure_parent_directory(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
 
 
-def _database_path() -> str:
-    uri = get_settings().database_uri
-    if uri.startswith("sqlite:///"):
-        location = uri[len("sqlite:///") :]
-        if location == ":memory:":
-            return ":memory:"
-        db_path = Path(location)
-        if db_path != Path(":memory:"):
-            _ensure_parent_directory(db_path)
-        return str(db_path)
-    raise RuntimeError(
-        "This lightweight storage layer currently supports only sqlite URIs."
+class Base(DeclarativeBase):
+    metadata = MetaData(schema=SCHEMA_NAME)
+
+
+class UserORM(Base):
+    """SQLAlchemy model storing matchmaking users."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    full_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    title: Mapped[Optional[str]] = mapped_column(String(255))
+    company: Mapped[Optional[str]] = mapped_column(String(255))
+    bio: Mapped[Optional[str]] = mapped_column(Text)
+    preferences: Mapped[List[Any]] = mapped_column(JSONB, default=list, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
     )
 
 
-def _connect() -> sqlite3.Connection:
-    global _CONNECTION
-    if _CONNECTION is None:
-        path = _database_path()
-        _CONNECTION = sqlite3.connect(
-            path,
-            check_same_thread=False,
-            detect_types=sqlite3.PARSE_DECLTYPES,
+class SwipeORM(Base):
+    """Model storing swipe interactions between users."""
+
+    __tablename__ = "swipes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey(f"{SCHEMA_NAME}.users.id", ondelete="CASCADE"), nullable=False
+    )
+    target_id: Mapped[int] = mapped_column(
+        ForeignKey(f"{SCHEMA_NAME}.users.id", ondelete="CASCADE"), nullable=False
+    )
+    action: Mapped[str] = mapped_column(String(16), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+
+
+class MatchORM(Base):
+    """Match between two profiles."""
+
+    __tablename__ = "matches"
+    __table_args__ = (UniqueConstraint("user_id", "matched_user_id", name="uq_match"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey(f"{SCHEMA_NAME}.users.id", ondelete="CASCADE"), nullable=False
+    )
+    matched_user_id: Mapped[int] = mapped_column(
+        ForeignKey(f"{SCHEMA_NAME}.users.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    score: Mapped["MatchScoreORM"] = relationship(
+        "MatchScoreORM", back_populates="match", uselist=False
+    )
+
+
+class MatchScoreORM(Base):
+    """Score associated with a match."""
+
+    __tablename__ = "match_scores"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    match_id: Mapped[int] = mapped_column(
+        ForeignKey(f"{SCHEMA_NAME}.matches.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    score: Mapped[float] = mapped_column(Float, nullable=False)
+    details: Mapped[Dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    match: Mapped[MatchORM] = relationship("MatchORM", back_populates="score")
+
+
+class SwipeEventORM(Base):
+    """Analytical events for swipe actions."""
+
+    __tablename__ = "swipe_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    swipe_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey(f"{SCHEMA_NAME}.swipes.id", ondelete="SET NULL")
+    )
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey(f"{SCHEMA_NAME}.users.id", ondelete="CASCADE"), nullable=False
+    )
+    target_id: Mapped[int] = mapped_column(
+        ForeignKey(f"{SCHEMA_NAME}.users.id", ondelete="CASCADE"), nullable=False
+    )
+    action: Mapped[str] = mapped_column(String(16), nullable=False)
+    score: Mapped[Optional[float]] = mapped_column(Float)
+    payload: Mapped[Dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+
+
+_ENGINE: Engine | None = None
+_SESSION_FACTORY: sessionmaker[Session] | None = None
+
+
+def get_engine() -> Engine:
+    """Return (and lazily create) the SQLAlchemy engine."""
+
+    global _ENGINE
+    if _ENGINE is None:
+        settings = get_settings()
+        _ENGINE = create_engine(settings.database_uri, **settings.engine_options)
+    return _ENGINE
+
+
+def reset_engine() -> None:
+    """Dispose of the existing engine and session factory."""
+
+    global _ENGINE, _SESSION_FACTORY
+    if _ENGINE is not None:
+        _ENGINE.dispose()
+    _ENGINE = None
+    _SESSION_FACTORY = None
+
+
+def _get_session_factory() -> sessionmaker[Session]:
+    global _SESSION_FACTORY
+    if _SESSION_FACTORY is None:
+        _SESSION_FACTORY = sessionmaker(
+            bind=get_engine(), expire_on_commit=False, future=True
         )
-        _CONNECTION.row_factory = sqlite3.Row
-        _CONNECTION.execute("PRAGMA foreign_keys = ON")
-    return _CONNECTION
-
-
-def init_db() -> None:
-    """Create database tables if they do not exist."""
-
-    with _LOCK:
-        conn = _connect()
-        cursor = conn.cursor()
-        cursor.executescript(
-            """
-            CREATE TABLE IF NOT EXISTS users (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                email TEXT NOT NULL UNIQUE,
-                full_name TEXT NOT NULL,
-                title TEXT,
-                company TEXT,
-                bio TEXT,
-                preferences TEXT NOT NULL,
-                is_active INTEGER NOT NULL,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS swipes (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                target_id INTEGER NOT NULL,
-                action TEXT NOT NULL,
-                created_at TEXT NOT NULL,
-                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
-                FOREIGN KEY(target_id) REFERENCES users(id) ON DELETE CASCADE
-            );
-
-            CREATE TABLE IF NOT EXISTS matches (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                matched_user_id INTEGER NOT NULL,
-                created_at TEXT NOT NULL,
-                UNIQUE(user_id, matched_user_id),
-                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
-                FOREIGN KEY(matched_user_id) REFERENCES users(id) ON DELETE CASCADE
-            );
-
-            CREATE TABLE IF NOT EXISTS match_scores (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                match_id INTEGER NOT NULL UNIQUE,
-                score REAL NOT NULL,
-                details TEXT,
-                created_at TEXT NOT NULL,
-                FOREIGN KEY(match_id) REFERENCES matches(id) ON DELETE CASCADE
-            );
-
-            CREATE TABLE IF NOT EXISTS swipe_events (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                swipe_id INTEGER,
-                event_type TEXT NOT NULL,
-                user_id INTEGER NOT NULL,
-                target_id INTEGER NOT NULL,
-                action TEXT NOT NULL,
-                score REAL,
-                payload TEXT,
-                created_at TEXT NOT NULL,
-                FOREIGN KEY(swipe_id) REFERENCES swipes(id) ON DELETE SET NULL
-            );
-            """
-        )
-        cursor.close()
-
-
-def reset_database() -> None:
-    """Drop and recreate all tables (mainly for tests)."""
-
-    with _LOCK:
-        conn = _connect()
-        cursor = conn.cursor()
-        cursor.executescript(
-            """
-            DROP TABLE IF EXISTS swipe_events;
-            DROP TABLE IF EXISTS match_scores;
-            DROP TABLE IF EXISTS matches;
-            DROP TABLE IF EXISTS swipes;
-            DROP TABLE IF EXISTS users;
-            """
-        )
-        cursor.close()
-    init_db()
-
-
-def _serialize_datetime(value: datetime) -> str:
-    return value.replace(microsecond=0).isoformat()
-
-
-def _now_text() -> str:
-    return _serialize_datetime(datetime.now(UTC))
+    return _SESSION_FACTORY
 
 
 @contextmanager
-def transaction_scope(commit: bool = True) -> Iterator[sqlite3.Cursor]:
-    """Provide a transactional cursor with simple retry logic."""
+def transaction_scope(commit: bool = True) -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
 
     settings = get_settings()
     attempts = max(1, settings.max_retries)
     delay = settings.retry_backoff
+    retries = 0
 
-    for attempt in range(attempts):
-        with _LOCK:
-            conn = _connect()
-            cursor = conn.cursor()
+    while True:
+        session = _get_session_factory()()
         try:
-            yield cursor
+            yield session
             if commit:
-                conn.commit()
+                session.commit()
             else:
-                conn.rollback()
-            cursor.close()
-            break
-        except sqlite3.OperationalError:
-            cursor.close()
-            conn.rollback()
-            if attempt >= attempts - 1:
+                session.rollback()
+            return
+        except OperationalError:
+            session.rollback()
+            retries += 1
+            if retries >= attempts:
                 raise
             time.sleep(delay)
             delay *= 2
         except Exception:
-            cursor.close()
-            conn.rollback()
+            session.rollback()
             raise
+        finally:
+            session.close()
 
 
-def create_user(user: User) -> User:
-    with transaction_scope() as cursor:
-        cursor.execute(
-            """
-            INSERT INTO users (email, full_name, title, company, bio, preferences, is_active, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                user.email,
-                user.full_name,
-                user.title,
-                user.company,
-                user.bio,
-                json.dumps(user.preferences),
-                int(user.is_active),
-                _serialize_datetime(user.created_at),
-                _serialize_datetime(user.updated_at),
-            ),
-        )
-        user.id = cursor.lastrowid
-    return user
+def _alembic_config() -> Config:
+    service_root = Path(__file__).resolve().parents[2]
+    cfg = Config(str(service_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(service_root / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", get_settings().database_uri)
+    return cfg
 
 
-def get_user(user_id: int) -> Optional[User]:
-    conn = _connect()
-    row = conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
-    if row is None:
-        return None
+def init_db() -> None:
+    """Ensure the database schema is up to date via Alembic migrations."""
+
+    command.upgrade(_alembic_config(), "head")
+
+
+def reset_database() -> None:
+    """Truncate all matching tables while preserving schema and migrations."""
+
+    engine = get_engine()
+    tables = ["swipe_events", "match_scores", "matches", "swipes", "users"]
+    with engine.begin() as connection:
+        for table in tables:
+            connection.execute(
+                text(
+                    f'TRUNCATE TABLE "{SCHEMA_NAME}"."{table}" RESTART IDENTITY CASCADE'
+                )
+            )
+
+
+def _to_domain_user(instance: UserORM) -> User:
     return User(
-        id=row["id"],
-        email=row["email"],
-        full_name=row["full_name"],
-        title=row["title"],
-        company=row["company"],
-        bio=row["bio"],
-        preferences=json.loads(row["preferences"] or "[]"),
-        is_active=bool(row["is_active"]),
-        created_at=datetime.fromisoformat(row["created_at"]),
-        updated_at=datetime.fromisoformat(row["updated_at"]),
+        id=instance.id,
+        email=instance.email,
+        full_name=instance.full_name,
+        title=instance.title,
+        company=instance.company,
+        bio=instance.bio,
+        preferences=list(instance.preferences or []),
+        is_active=bool(instance.is_active),
+        created_at=instance.created_at,
+        updated_at=instance.updated_at,
     )
 
 
+def _ensure_datetimes(user: User) -> None:
+    if user.created_at is None:
+        user.created_at = _utcnow()
+    if user.updated_at is None:
+        user.updated_at = _utcnow()
+
+
+def upsert_user(user: User) -> User:
+    """Insert or update a user profile."""
+
+    _ensure_datetimes(user)
+    with transaction_scope() as session:
+        instance: UserORM | None = None
+        if user.id is not None:
+            instance = session.get(UserORM, user.id)
+        if instance is None:
+            stmt = select(UserORM).where(UserORM.email == user.email)
+            instance = session.execute(stmt).scalar_one_or_none()
+        if instance is None:
+            instance = UserORM()
+        if user.id is not None:
+            instance.id = user.id
+        instance.email = user.email
+        instance.full_name = user.full_name
+        instance.title = user.title
+        instance.company = user.company
+        instance.bio = user.bio
+        instance.preferences = list(user.preferences or [])
+        instance.is_active = bool(user.is_active)
+        instance.created_at = user.created_at
+        instance.updated_at = user.updated_at
+        session.add(instance)
+        session.flush()
+        user.id = instance.id
+        return _to_domain_user(instance)
+
+
+def create_user(user: User) -> User:
+    """Compatibility wrapper calling :func:`upsert_user`."""
+
+    return upsert_user(user)
+
+
+def get_user(user_id: int) -> Optional[User]:
+    with transaction_scope(commit=False) as session:
+        instance = session.get(UserORM, user_id)
+        if instance is None:
+            return None
+        return _to_domain_user(instance)
+
+
+def list_users(
+    exclude_user_id: int | None = None, only_active: bool = True
+) -> List[User]:
+    with transaction_scope(commit=False) as session:
+        stmt = select(UserORM)
+        if only_active:
+            stmt = stmt.where(UserORM.is_active.is_(True))
+        if exclude_user_id is not None:
+            stmt = stmt.where(UserORM.id != exclude_user_id)
+        stmt = stmt.order_by(UserORM.id)
+        rows = session.execute(stmt).scalars().all()
+        return [_to_domain_user(row) for row in rows]
+
+
 def create_swipe(swipe: Swipe) -> Swipe:
-    with transaction_scope() as cursor:
-        cursor.execute(
-            """
-            INSERT INTO swipes (user_id, target_id, action, created_at)
-            VALUES (?, ?, ?, ?)
-            """,
-            (
-                swipe.user_id,
-                swipe.target_id,
-                swipe.action,
-                _serialize_datetime(swipe.created_at),
-            ),
+    if swipe.created_at is None:
+        swipe.created_at = _utcnow()
+    with transaction_scope() as session:
+        instance = SwipeORM(
+            user_id=swipe.user_id,
+            target_id=swipe.target_id,
+            action=swipe.action,
+            created_at=swipe.created_at,
         )
-        swipe.id = cursor.lastrowid
-    return swipe
+        session.add(instance)
+        session.flush()
+        swipe.id = instance.id
+        return swipe
 
 
 def has_mutual_like(user_id: int, target_id: int) -> bool:
-    conn = _connect()
-    row = conn.execute(
-        """
-        SELECT id FROM swipes
-        WHERE user_id = ? AND target_id = ? AND action = 'like'
-        ORDER BY created_at DESC
-        LIMIT 1
-        """,
-        (target_id, user_id),
-    ).fetchone()
-    return row is not None
+    with transaction_scope(commit=False) as session:
+        stmt = select(SwipeORM.id).where(
+            SwipeORM.user_id == target_id,
+            SwipeORM.target_id == user_id,
+            SwipeORM.action == "like",
+        )
+        return session.execute(stmt).first() is not None
 
 
 def create_matches(
@@ -260,162 +360,134 @@ def create_matches(
     score: float,
     common_interests: Iterable[str],
 ) -> List[int]:
-    details_json = json.dumps({"common_interests": list(common_interests)})
-    created_at = _now_text()
+    details = {"common_interests": list(common_interests)}
     match_ids: List[int] = []
-
-    with transaction_scope() as cursor:
+    with transaction_scope() as session:
+        now = _utcnow()
         for left, right in ((user_id, target_id), (target_id, user_id)):
-            cursor.execute(
-                """
-                INSERT OR IGNORE INTO matches (user_id, matched_user_id, created_at)
-                VALUES (?, ?, ?)
-                """,
-                (left, right, created_at),
+            stmt = select(MatchORM).where(
+                MatchORM.user_id == left, MatchORM.matched_user_id == right
             )
-            if cursor.rowcount == 0:
-                existing = cursor.execute(
-                    "SELECT id FROM matches WHERE user_id = ? AND matched_user_id = ?",
-                    (left, right),
-                ).fetchone()
-                match_id = existing["id"]
+            match = session.execute(stmt).scalar_one_or_none()
+            if match is None:
+                match = MatchORM(user_id=left, matched_user_id=right, created_at=now)
+                session.add(match)
+                session.flush()
+            match_ids.append(match.id)
+            if match.score is None:
+                match.score = MatchScoreORM(
+                    match_id=match.id, score=score, details=details, created_at=now
+                )
             else:
-                match_id = cursor.lastrowid
-            cursor.execute(
-                """
-                INSERT OR REPLACE INTO match_scores (match_id, score, details, created_at)
-                VALUES (?, ?, ?, ?)
-                """,
-                (match_id, score, details_json, created_at),
-            )
-            match_ids.append(match_id)
+                match.score.score = score
+                match.score.details = details
+                match.score.created_at = now
+            session.add(match)
     return match_ids
 
 
 def log_swipe_event(event: SwipeEvent) -> SwipeEvent:
-    with transaction_scope() as cursor:
-        cursor.execute(
-            """
-            INSERT INTO swipe_events (swipe_id, event_type, user_id, target_id, action, score, payload, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                event.swipe_id,
-                event.event_type,
-                event.user_id,
-                event.target_id,
-                event.action,
-                event.score,
-                json.dumps(event.payload),
-                _serialize_datetime(event.created_at),
-            ),
+    if event.created_at is None:
+        event.created_at = _utcnow()
+    with transaction_scope() as session:
+        instance = SwipeEventORM(
+            swipe_id=event.swipe_id,
+            event_type=event.event_type,
+            user_id=event.user_id,
+            target_id=event.target_id,
+            action=event.action,
+            score=event.score,
+            payload=dict(event.payload or {}),
+            created_at=event.created_at,
         )
-        event.id = cursor.lastrowid
-    return event
+        session.add(instance)
+        session.flush()
+        event.id = instance.id
+        return event
 
 
-
-
-def list_users(exclude_user_id: int | None = None, only_active: bool = True) -> List[User]:
-    """Return users stored in the database."""
-
-    conn = _connect()
-    clauses = []
-    params: List[object] = []
-    if only_active:
-        clauses.append("is_active = 1")
-    if exclude_user_id is not None:
-        clauses.append("id != ?")
-        params.append(exclude_user_id)
-    where_clause = ""
-    if clauses:
-        where_clause = " WHERE " + " AND ".join(clauses)
-    rows = conn.execute(
-        "SELECT * FROM users" + where_clause + " ORDER BY id", tuple(params)
-    ).fetchall()
-    users: List[User] = []
-    for row in rows:
-        users.append(
-            User(
-                id=row["id"],
-                email=row["email"],
-                full_name=row["full_name"],
-                title=row["title"],
-                company=row["company"],
-                bio=row["bio"],
-                preferences=json.loads(row["preferences"] or "[]"),
-                is_active=bool(row["is_active"]),
-                created_at=datetime.fromisoformat(row["created_at"]),
-                updated_at=datetime.fromisoformat(row["updated_at"]),
+def fetch_matches_for_user(user_id: int) -> List[Dict[str, Any]]:
+    partner = aliased(UserORM)
+    with transaction_scope(commit=False) as session:
+        stmt = (
+            select(
+                MatchORM.id.label("match_id"),
+                MatchORM.created_at.label("created_at"),
+                partner.id.label("partner_id"),
+                partner.full_name.label("full_name"),
+                partner.title.label("title"),
+                partner.company.label("company"),
+                partner.preferences.label("preferences"),
+                MatchScoreORM.score.label("score"),
+                MatchScoreORM.details.label("details"),
             )
+            .join(partner, MatchORM.matched_user_id == partner.id)
+            .outerjoin(MatchScoreORM, MatchScoreORM.match_id == MatchORM.id)
+            .where(MatchORM.user_id == user_id)
+            .order_by(MatchORM.created_at.desc())
         )
-    return users
-
-
-def fetch_matches_for_user(user_id: int) -> List[Dict[str, object]]:
-    conn = _connect()
-    rows = conn.execute(
-        """
-        SELECT m.id as match_id, m.created_at, u.id as partner_id, u.full_name, u.title, u.company,
-               u.preferences, s.score, s.details
-        FROM matches m
-        LEFT JOIN users u ON u.id = m.matched_user_id
-        LEFT JOIN match_scores s ON s.match_id = m.id
-        WHERE m.user_id = ?
-        ORDER BY m.created_at DESC
-        """,
-        (user_id,),
-    ).fetchall()
-
-    results: List[Dict[str, object]] = []
-    for row in rows:
-        preferences = json.loads(row["preferences"] or "[]") if row["preferences"] else []
-        details = json.loads(row["details"] or "{}") if row["details"] else {}
-        results.append(
-            {
-                "id": row["match_id"],
-                "user_id": row["partner_id"],
-                "name": row["full_name"],
-                "title": row["title"],
-                "company": row["company"],
-                "match_score": row["score"],
-                "preferences": preferences,
-                "common_interests": details.get("common_interests", []),
-                "created_at": row["created_at"],
-            }
-        )
-    return results
+        results: List[Dict[str, Any]] = []
+        for row in session.execute(stmt):
+            preferences = list(row.preferences or [])
+            details = dict(row.details or {})
+            results.append(
+                {
+                    "id": row.match_id,
+                    "user_id": row.partner_id,
+                    "name": row.full_name,
+                    "title": row.title,
+                    "company": row.company,
+                    "match_score": row.score,
+                    "preferences": preferences,
+                    "common_interests": details.get("common_interests", []),
+                    "created_at": row.created_at.isoformat(),
+                }
+            )
+        return results
 
 
 def count_rows(table: str) -> int:
-    conn = _connect()
-    row = conn.execute(f"SELECT COUNT(*) as count FROM {table}").fetchone()
-    return int(row["count"])
+    with transaction_scope(commit=False) as session:
+        stmt = text(f'SELECT COUNT(*) FROM "{SCHEMA_NAME}"."{table}"')
+        return int(session.execute(stmt).scalar_one())
 
 
-def fetch_swipe_events() -> List[Dict[str, object]]:
-    conn = _connect()
-    rows = conn.execute(
-        """
-        SELECT id, swipe_id, event_type, user_id, target_id, action, score, payload, created_at
-        FROM swipe_events
-        ORDER BY id
-        """
-    ).fetchall()
-    events: List[Dict[str, object]] = []
-    for row in rows:
-        events.append(
-            {
-                "id": row["id"],
-                "swipe_id": row["swipe_id"],
-                "event_type": row["event_type"],
-                "user_id": row["user_id"],
-                "target_id": row["target_id"],
-                "action": row["action"],
-                "score": row["score"],
-                "payload": json.loads(row["payload"] or "{}"),
-                "created_at": row["created_at"],
-            }
-        )
-    return events
+def fetch_swipe_events() -> List[Dict[str, Any]]:
+    with transaction_scope(commit=False) as session:
+        stmt = select(SwipeEventORM).order_by(SwipeEventORM.id)
+        events: List[Dict[str, Any]] = []
+        for instance in session.execute(stmt).scalars():
+            events.append(
+                {
+                    "id": instance.id,
+                    "swipe_id": instance.swipe_id,
+                    "event_type": instance.event_type,
+                    "user_id": instance.user_id,
+                    "target_id": instance.target_id,
+                    "action": instance.action,
+                    "score": instance.score,
+                    "payload": dict(instance.payload or {}),
+                    "created_at": instance.created_at.isoformat(),
+                }
+            )
+        return events
 
+
+__all__ = [
+    "Base",
+    "count_rows",
+    "create_matches",
+    "create_swipe",
+    "create_user",
+    "fetch_matches_for_user",
+    "fetch_swipe_events",
+    "get_engine",
+    "get_user",
+    "has_mutual_like",
+    "init_db",
+    "log_swipe_event",
+    "reset_database",
+    "reset_engine",
+    "transaction_scope",
+    "upsert_user",
+]

--- a/services/matching-service/tests/conftest.py
+++ b/services/matching-service/tests/conftest.py
@@ -1,30 +1,59 @@
 """Pytest configuration for the matching service tests."""
 
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path
 
-
-os.environ.setdefault("DATABASE_URI", "sqlite:///:memory:")
+import pytest
+from testcontainers.postgres import PostgresContainer
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from src.storage import init_db, reset_database
+from src.config import refresh_settings  # noqa: E402
+from src.storage import init_db, reset_database, reset_engine  # noqa: E402
 
 
-import pytest
+POSTGRES_CONTAINER: PostgresContainer | None = None
+CONTAINER_ERROR: Exception | None = None
+
+
+def _bootstrap_postgres() -> None:
+    global POSTGRES_CONTAINER, CONTAINER_ERROR
+    try:
+        POSTGRES_CONTAINER = PostgresContainer("postgres:15-alpine")
+        POSTGRES_CONTAINER.start()
+        connection_url = POSTGRES_CONTAINER.get_connection_url()
+        database_uri = connection_url.replace("psycopg2", "psycopg") + "?options=-csearch_path%3Dmatching"
+        os.environ["DATABASE_URI"] = database_uri
+        os.environ.pop("MATCHING_SKIP_DB_INIT", None)
+        refresh_settings()
+        reset_engine()
+        init_db()
+    except Exception as exc:  # pragma: no cover - infrastructure failure
+        CONTAINER_ERROR = exc
+        POSTGRES_CONTAINER = None
+        os.environ["MATCHING_SKIP_DB_INIT"] = "1"
+
+
+_bootstrap_postgres()
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _initialize_database():
-    init_db()
-    reset_database()
+def _postgres_database():
+    if CONTAINER_ERROR is not None:
+        pytest.skip(f"PostgreSQL container unavailable: {CONTAINER_ERROR}")
     yield
+    if POSTGRES_CONTAINER is not None:
+        POSTGRES_CONTAINER.stop()
 
 
 @pytest.fixture(autouse=True)
 def _clean_database():
+    if CONTAINER_ERROR is not None:
+        pytest.skip(f"PostgreSQL container unavailable: {CONTAINER_ERROR}")
     reset_database()
     yield

--- a/services/matching-service/tests/test_ingestion.py
+++ b/services/matching-service/tests/test_ingestion.py
@@ -1,0 +1,63 @@
+"""Tests for the ingestion endpoints used by the user service."""
+
+from __future__ import annotations
+
+from src.main import app
+from src.storage import get_user
+
+
+def test_ingest_users_creates_profiles():
+    payload = {
+        "users": [
+            {
+                "id": 501,
+                "email": "ingest-create@example.com",
+                "full_name": "Ingest Create",
+                "title": "Data Scientist",
+                "company": "Meetinity",
+                "preferences": {"skills": ["python", "ml"]},
+            }
+        ]
+    }
+
+    with app.test_client() as client:
+        response = client.post("/internal/users", json=payload)
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ingested"] == 1
+    stored_id = body["user_ids"][0]
+
+    stored_user = get_user(stored_id)
+    assert stored_user is not None
+    assert stored_user.email == "ingest-create@example.com"
+    assert any("python" in str(item).lower() for item in stored_user.preferences)
+
+
+def test_ingest_users_updates_existing_profile():
+    initial_payload = {
+        "id": 777,
+        "email": "ingest-update@example.com",
+        "full_name": "Initial Name",
+        "preferences": ["cloud"],
+    }
+
+    update_payload = {
+        "id": 777,
+        "email": "ingest-update@example.com",
+        "full_name": "Updated Name",
+        "preferences": {"skills": ["kafka"]},
+    }
+
+    with app.test_client() as client:
+        first = client.post("/internal/users", json=initial_payload)
+        assert first.status_code == 200
+        second = client.post("/internal/users", json=update_payload)
+
+    assert second.status_code == 200
+    body = second.get_json()
+    assert body["ingested"] == 1
+    stored_user = get_user(777)
+    assert stored_user is not None
+    assert stored_user.full_name == "Updated Name"
+    assert any("kafka" in str(item).lower() for item in stored_user.preferences)


### PR DESCRIPTION
## Summary
- replace the matching service's sqlite helper with SQLAlchemy models, Alembic migrations, and a PostgreSQL schema
- expose an `/internal/users` ingestion endpoint to upsert user profiles into the matching store and update automated tests
- update Docker/dev tooling and seed data so the matching service boots against PostgreSQL alongside the rest of the stack

## Testing
- pytest *(skipped: requires Docker to start the PostgreSQL test container in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da01c82e4883329856338ad374c3ec