### PR TITLE
Add integration tests for gateway flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,28 @@ jobs:
         if: steps.node_manifests.outputs.has_package != 'true'
         run: echo 'No package.json found. Skipping tests.'
 
+  integration-tests:
+    name: Integration Tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pytest requests PyJWT
+
+      - name: Confirm Docker availability
+        run: docker compose version
+
+      - name: Run integration suite
+        run: pytest -m integration tests/integration -vv
+
   security_scan:
     name: Security Scan
     needs: build

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,69 @@
+# Testing Guide
+
+This document explains how to run the end-to-end integration suite that exercises the Meetinity microservices stack through the API gateway.
+
+## Prerequisites
+
+Make sure the following tooling is available locally:
+
+- Docker Engine 24+ with Compose v2 (`docker compose` CLI)
+- Python 3.11 or newer
+- `pip` to install Python testing dependencies
+- Available local ports `5432`, `8080`–`8084`, and `8089` (the Docker stack binds to these during tests)
+
+Before running the suite, install the minimal Python dependencies used by the tests:
+
+```bash
+pip install pytest requests PyJWT
+```
+
+## Running the integration suite
+
+1. From the repository root, execute the integration tests with pytest:
+
+   ```bash
+   pytest -m integration tests/integration -vv
+   ```
+
+   The session-scoped fixture defined in `tests/integration/conftest.py` will:
+
+   - Build the service images referenced by `docker-compose.dev.yml`
+   - Start the required containers (Postgres, Kafka, User, Event, Matching services, and the API gateway)
+   - Seed deterministic reference data using `scripts/dev/sql/seed.sql`
+   - Wait for the HTTP health checks on each service before executing the tests
+
+2. After the suite completes, the fixture automatically tears down the stack with `docker compose down -v --remove-orphans`.
+
+### Running individual flows
+
+Each test covers a key user journey:
+
+- `test_login_flow_through_gateway` posts a JWT to `/api/auth/verify` via the gateway and asserts the token is accepted.
+- `test_event_registration_roundtrip` registers, lists, and cancels an event registration through the gateway, verifying the registration service behaviour.
+- `test_swipe_flow_triggers_match` records a like swipe and asserts the matching service detects the existing mutual match.
+
+You can execute a single test while still reusing the fixture-managed stack:
+
+```bash
+pytest tests/integration/test_flows.py::test_swipe_flow_triggers_match -vv
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Suggested fix |
+| --- | --- | --- |
+| `docker: command not found` or `Cannot connect to the Docker daemon` | Docker Engine is not installed or not running | Install/start Docker or run the suite on a host with Docker available |
+| `Timed out waiting for service at http://localhost:8080/health` | Containers are still starting, or a previous run left ports bound | Retry the test after `docker compose down -v`; ensure no conflicting local services use the same ports |
+| `duplicate key value violates unique constraint` during seeding | Database volume persisted between runs | Remove the `meetinity_integration` volumes with `docker compose -f docker-compose.dev.yml down -v --remove-orphans` |
+| `pytest` cannot import `jwt` | `PyJWT` dependency missing | Re-run `pip install pytest requests PyJWT` |
+
+If you need to inspect container logs while the suite is running, open a separate terminal and run:
+
+```bash
+docker compose -f docker-compose.dev.yml logs -f api-gateway user-service event-service matching-service
+```
+
+## Continuous integration
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) now contains an `Integration Tests` job that provisions the same stack and executes `pytest -m integration` automatically on pull requests.
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    integration: Tests that exercise the docker-compose stack end-to-end.
+testpaths =
+    tests

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+import requests
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+COMPOSE_FILE = ROOT_DIR / "docker-compose.dev.yml"
+STACK_SERVICES = (
+    "postgres",
+    "zookeeper",
+    "kafka",
+    "user-service",
+    "event-service",
+    "matching-service",
+    "api-gateway",
+)
+HEALTH_CHECKS = (
+    "http://localhost:8081/health",
+    "http://localhost:8083/health",
+    "http://localhost:8082/health",
+    "http://localhost:8080/health",
+)
+
+
+def _compose_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("COMPOSE_PROJECT_NAME", "meetinity_integration")
+    return env
+
+
+def _run_compose(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    command = [
+        "docker",
+        "compose",
+        "-f",
+        str(COMPOSE_FILE),
+        *args,
+    ]
+    return subprocess.run(
+        command,
+        check=check,
+        env=_compose_env(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _wait_for_http(url: str, timeout: float = 180.0, interval: float = 2.0) -> None:
+    deadline = time.time() + timeout
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            response = requests.get(url, timeout=5)
+            if response.status_code < 500:
+                return
+        except requests.RequestException as exc:  # pragma: no cover - retry loop
+            last_error = exc
+        time.sleep(interval)
+    message = f"Timed out waiting for service at {url}"
+    if last_error is not None:
+        message = f"{message}: {last_error}"
+    raise RuntimeError(message)
+
+
+@pytest.fixture(scope="session")
+def docker_stack() -> Iterator[dict[str, str]]:
+    if not COMPOSE_FILE.exists():
+        pytest.skip("Docker Compose file missing; integration stack unavailable")
+    if shutil.which("docker") is None:
+        pytest.skip("Docker is required to run integration tests")
+
+    try:
+        _run_compose("down", "-v", "--remove-orphans", check=False)
+        _run_compose("build", *STACK_SERVICES)
+        _run_compose("up", "-d", *STACK_SERVICES)
+    except subprocess.CalledProcessError as exc:
+        pytest.skip(f"Unable to start docker-compose stack: {exc.stdout}")
+
+    try:
+        for url in HEALTH_CHECKS:
+            _wait_for_http(url)
+        # Seed deterministic fixtures
+        _run_compose("--profile", "seed", "run", "--rm", "seed-data")
+        _wait_for_http("http://localhost:8080/health")
+        yield {"gateway": "http://localhost:8080"}
+    finally:
+        _run_compose("down", "-v", "--remove-orphans", check=False)
+
+
+@pytest.fixture(scope="session")
+def gateway_base_url(docker_stack: dict[str, str]) -> str:
+    return docker_stack["gateway"]

--- a/tests/integration/test_flows.py
+++ b/tests/integration/test_flows.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+import jwt
+import pytest
+import requests
+
+USER_ID = 9000
+USER_EMAIL = "alice.martin@example.com"
+USER_PROVIDER = "google"
+EVENT_ID = 500
+TARGET_USER_ID = 9001
+
+
+@pytest.fixture(scope="session")
+def auth_token() -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": USER_ID,
+        "email": USER_EMAIL,
+        "provider": USER_PROVIDER,
+        "iat": now,
+        "exp": now + timedelta(minutes=30),
+    }
+    return jwt.encode(payload, "change_me", algorithm="HS256")
+
+
+@pytest.fixture(scope="session")
+def auth_headers(auth_token: str) -> Dict[str, str]:
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("docker_stack")
+def test_login_flow_through_gateway(gateway_base_url: str, auth_token: str) -> None:
+    response = requests.post(
+        f"{gateway_base_url}/api/auth/verify",
+        json={"token": auth_token},
+        timeout=15,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    assert payload["valid"] is True
+    assert payload["sub"] == USER_ID
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("docker_stack")
+def test_event_registration_roundtrip(gateway_base_url: str, auth_headers: Dict[str, str]) -> None:
+    attendee_email = "integration.attendee@example.com"
+    join_response = requests.post(
+        f"{gateway_base_url}/api/events/events/{EVENT_ID}/join",
+        headers=auth_headers,
+        json={"email": attendee_email, "name": "Integration Attendee"},
+        timeout=30,
+    )
+    join_response.raise_for_status()
+    registration = join_response.json()
+    assert registration["success"] is True
+    registration_id = registration["registration_id"]
+    assert registration_id
+
+    list_response = requests.get(
+        f"{gateway_base_url}/api/events/events/{EVENT_ID}/registrations",
+        headers=auth_headers,
+        timeout=30,
+    )
+    list_response.raise_for_status()
+    registrations = list_response.json()["registrations"]
+    assert any(item["attendee_email"] == attendee_email for item in registrations)
+
+    cancel_response = requests.delete(
+        f"{gateway_base_url}/api/events/events/{EVENT_ID}/join",
+        headers=auth_headers,
+        params={"registration_id": registration_id},
+        timeout=30,
+    )
+    cancel_response.raise_for_status()
+    cancel_payload = cancel_response.json()
+    assert cancel_payload["success"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("docker_stack")
+def test_swipe_flow_triggers_match(gateway_base_url: str, auth_headers: Dict[str, str]) -> None:
+    response = requests.post(
+        f"{gateway_base_url}/api/matching/swipe",
+        headers=auth_headers,
+        json={"user_id": USER_ID, "target_id": TARGET_USER_ID, "action": "like"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    assert payload["user_id"] == USER_ID
+    assert payload["target_id"] == TARGET_USER_ID
+    assert payload["action"] == "like"
+    assert payload["is_match"] is True
+    assert payload.get("match_score") is not None


### PR DESCRIPTION
## Summary
- add pytest-based integration tests that start the docker-compose stack and exercise login, registration, and matching flows
- register an integration test marker/configuration and document execution plus troubleshooting guidance
- wire the new integration suite into CI with a dedicated GitHub Actions job

## Testing
- pytest --collect-only tests/integration/test_flows.py

------
https://chatgpt.com/codex/tasks/task_e_68da119e16f88332bd8f9dbd7680dccb