### PR TITLE
Refine documentation around MVP priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ make dev-down
 
 ### Technical Architecture
 
-The project uses a modern **microservices architecture**:
+The project uses a modern **microservices architecture**. All backend services now live in the [`services/`](services/) directory to streamline local development and deployments:
 
-- **API Gateway**: Flask-based request routing and authentication
-- **User Service**: OAuth authentication and profile management
-- **Event Service**: Event creation, discovery, and registration
-- **Matching Service**: Professional matching algorithms and swipe functionality
+- **API Gateway** (`services/api-gateway`): Flask-based request routing and authentication
+- **User Service** (`services/user-service`): OAuth authentication and profile management
+- **Event Service** (`services/event-service`): Event creation, discovery, and registration
+- **Matching Service** (`services/matching-service`): Professional matching algorithms and swipe functionality
 - **Mobile App**: React 18 with TypeScript and Vite
 - **Admin Portal**: React-based administration interface
 - **Database**: PostgreSQL for data persistence
@@ -94,22 +94,26 @@ The project uses a modern **microservices architecture**:
 
 ### Cloud Infrastructure Enhancements
 
+Our infrastructure baseline is now fully documented and automated:
+
 - **Static assets CDN**: Private S3 bucket fronted by CloudFront with optional custom domains.
 - **Shared load balancers**: Pre-provisioned ALB (HTTP/HTTPS) and NLB (TCP) endpoints for workloads that cannot rely on the ingress controller.
 - **Automated backups**: Daily AWS Backup plan covering the Aurora PostgreSQL cluster with configurable retention.
 - **Cost monitoring**: Monthly AWS Budget notifications to alert the platform team and finance stakeholders.
+- **Infrastructure as Code**: Terraform modules, Helm charts, and deployment scripts described in [`docs/cloud-operations.md`](docs/cloud-operations.md), [`docs/containerization-roadmap.md`](docs/containerization-roadmap.md), [`docs/observability.md`](docs/observability.md), and [`docs/autoscaling-playbook.md`](docs/autoscaling-playbook.md).
 
-### Repository Structure
+### Repository Structure & Progress
 
-| Repository | Description | Status |
+| Component | Location | Status |
 |---|---|---|
-| **meetinity** | Main repository with API contracts and documentation | 15% - Specifications defined |
-| **meetinity-mobile-app** | React mobile application for end users | 70% - Functional with OAuth |
-| **meetinity-admin-portal** | React administration interface | 60% - User management complete |
-| **meetinity-api-gateway** | Flask API gateway for request routing | 40% - Basic routing implemented |
-| **meetinity-user-service** | Flask user management and authentication | 80% - Complete OAuth and profiles |
-| **meetinity-matching-service** | Flask matching algorithms and swipe logic | 25% - Basic algorithms implemented |
-| **meetinity-event-service** | Flask event management system | 35% - REST API with validation |
+| **Documentation & Contracts** | `docs/`, `contracts/` | 25% – Core specifications consolidated, awaiting final data models |
+| **API Gateway** | `services/api-gateway` | 45% – Auth pass-through and routing ready, needs coverage for event/messaging flows |
+| **User Service** | `services/user-service` | 80% – OAuth + profiles stable, pending messaging profile hooks |
+| **Event Service** | `services/event-service` | 40% – REST API scaffolding complete, registration storage outstanding |
+| **Matching Service** | `services/matching-service` | 30% – Matching logic prototype, requires data sync with events/users |
+| **Messaging (planned)** | `services/` (new) | 10% – Container baseline prepared, functionality to be implemented |
+| **Mobile App** | External repo `meetinity-mobile-app` | 70% – Authentication and discovery UI shipped |
+| **Admin Portal** | External repo `meetinity-admin-portal` | 60% – User management complete |
 
 ## 🤝 How to Contribute?
 
@@ -132,10 +136,10 @@ We welcome all contributions! Whether you are:
 A comprehensive technical evaluation was conducted in September 2025, revealing strong foundations with strategic opportunities for growth.
 
 - **Key Strengths**: Robust OAuth authentication, modern React frontends, clean microservices architecture
-- **Critical Issues**: Database integration problems in user-service, incomplete CI/CD infrastructure
-- **Priority Actions**: Resolve database issues, complete event and matching services, implement networking features
+- **Critical Issues**: Event registrations, cross-service data synchronisation, and messaging flows still pending
+- **Priority Actions**: Expand gateway coverage, deliver registrations & matching data sync, implement networking features
 
-Find the detailed evaluation and strategic roadmap in [`docs/project-evaluation.md`](docs/project-evaluation.md) and [`TODO.md`](TODO.md).
+Find the detailed evaluation and strategic roadmap in [`docs/project-evaluation.md`](docs/project-evaluation.md), [`docs/cloud-operations.md`](docs/cloud-operations.md), and [`TODO.md`](TODO.md).
 
 ## 📞 Support and Community
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,88 +1,47 @@
-# Liste de Tâches du Projet Meetinity
+# Plan d'Action Prioritaire Meetinity (MVP)
 
-Ce document présente une liste de tâches dense et priorisée pour guider la prochaine phase de développement de la plateforme Meetinity. Elle est basée sur une évaluation complète de l'état actuel des repositories et des objectifs de l'application.
+L'infrastructure, les pipelines CI/CD et la base Terraform sont livrés. La priorité passe désormais à l'expérience utilisateur : finaliser la couverture de l'API Gateway, sécuriser les inscriptions aux événements, synchroniser les données de matching et activer la messagerie. Les tâches ci-dessous sont triées par impact direct sur l'obtention d'un MVP fonctionnel.
 
-## EPIC 1: Solidifier l'Infrastructure et le DevOps
+## EPIC 1 – API Gateway prête pour le MVP
 
-Cet épique se concentre sur la stabilisation de la base technique du projet, la résolution des problèmes critiques et la mise en place d'une automatisation complète.
+### Tâche 1.1 – Couverture des parcours clés
+- **Description :** Étendre les routes de la passerelle pour exposer l'ensemble des flux `event-service`, `matching-service` et le futur service de messagerie, avec un routage basé sur les rôles et une gestion des erreurs homogène.
+- **Livrables :** Nouvelles routes documentées, politiques d'autorisation consolidées, tests d'intégration couvrant les flux critiques.
 
-### Tâche 1.1: Résoudre l'Intégration Critique de la Base de Données du User Service
+### Tâche 1.2 – Observabilité et résilience
+- **Description :** Ajouter traçabilité distribuée, métriques et budget d'erreurs sur l'API Gateway en s'appuyant sur les normes décrites dans [`docs/observability.md`](docs/observability.md) et [`docs/autoscaling-playbook.md`](docs/autoscaling-playbook.md).
+- **Livrables :** Tableaux de bord et alertes configurés, tests de charge validant la tolérance aux pannes, mise à jour de la documentation opérateur.
 
-*   **Description:** Le `user-service` présente une issue critique qui empêche la persistance correcte des données. Cette tâche exige une analyse approfondie de la configuration de SQLAlchemy et Alembic, le diagnostic des problèmes de connexion et de migration, et l'implémentation d'un correctif robuste. Cela inclut la rédaction de tests d'intégration complets pour valider la persistance des données après redémarrage du service et pour garantir que le schéma de la base de données de production est stable et correct.
-*   **Livrables:** Code du `user-service` corrigé, suite de tests d'intégration réussie, documentation de la configuration de la base de données.
-*   **Issue Associée:** `decarvalhoe/meetinity-user-service#14`
+## EPIC 2 – Inscriptions aux événements fiables
 
-### Tâche 1.2: Implémenter un Pipeline CI/CD Complet pour Tous les Services
+### Tâche 2.1 – Persistance et quotas
+- **Description :** Connecter le `event-service` à PostgreSQL, modéliser les inscriptions et gérer les quotas/attentes conformément aux contrats OpenAPI.
+- **Livrables :** Migrations Alembic, endpoints `/events/{id}/register` et `/events/{id}/attendees`, tests d'intégration.
 
-*   **Description:** Configurer les workflows GitHub Actions existants (`ci.yml`, `cd.yml`) avec les secrets et la logique de déploiement requis. Cela implique la création de scripts de déploiement (par exemple, en utilisant Docker, Kubernetes) pour chaque microservice et les applications frontend. Le pipeline doit automatiser la construction, les tests et le déploiement des services vers un environnement de staging à chaque push sur la branche `main`, et vers la production lors de la création d'un nouveau tag de version.
-*   **Livrables:** Pipelines CI/CD entièrement opérationnels, scripts de déploiement, `README.md` mis à jour avec les instructions de déploiement.
-*   **Issue Associée:** `decarvalhoe/meetinity#1`
+### Tâche 2.2 – Notifications et synchronisation
+- **Description :** Publier des événements métier (Kafka ou Redis Streams) lors des inscriptions et exposer des webhooks pour informer le portail admin.
+- **Livrables :** Producteurs d'événements, documentation d'abonnement, scripts d'exemple pour la consommation.
 
-### Tâche 1.3: Définir et Documenter l'Architecture des Données
+## EPIC 3 – Matching connecté aux données réelles
 
-*   **Description:** Créer un document complet détaillant les modèles de données pour chaque service, les relations entre eux, et la stratégie globale de flux et d'intégration des données. Cela inclut la définition de la "source de vérité" pour chaque donnée, les stratégies de synchronisation des données entre les services (par exemple, en utilisant des événements via Kafka), et la création de diagrammes entité-relation (ERD) détaillés.
-*   **Livrables:** Un fichier `docs/data-architecture.md` avec des ERDs et des descriptions détaillées du flux de données.
-*   **Issue Associée:** `decarvalhoe/meetinity#3`
+### Tâche 3.1 – Pipeline de données profils & disponibilités
+- **Description :** Synchroniser les profils et préférences depuis le `user-service`, ainsi que les disponibilités d'événements depuis le `event-service`, via des jobs planifiés ou des événements.
+- **Livrables :** Jobs d'ingestion, stockage normalisé, tests garantissant la cohérence des données.
 
-## EPIC 2: Finaliser les Services Backend de Base (Event & Matching)
+### Tâche 3.2 – Algorithmes prêts pour la production
+- **Description :** Remplacer les données factices par le pipeline réel, recalibrer les scores de matching et exposer des endpoints paginés pour le mobile et l'admin.
+- **Livrables :** Nouvelles métriques de pertinence, documentation de tuning, tests de performance.
 
-Cet épique vise à compléter les fonctionnalités de base des services `event-service` et `matching-service` pour les rendre pleinement opérationnels.
+## EPIC 4 – Messagerie MVP
 
-### Tâche 2.1: Finaliser l'Event Service avec Base de Données et Inscription
+### Tâche 4.1 – Service de conversations
+- **Description :** Définir l'architecture (WebSocket + Redis Streams ou équivalent), créer le service de messagerie et ses contrats (REST + WebSocket) avec authentification via la Gateway.
+- **Livrables :** Service conteneurisé dans `services/messaging-service`, schéma de données, tests d'acceptation.
 
-*   **Description:** Intégrer une base de données PostgreSQL en utilisant SQLAlchemy, implémenter Alembic pour les migrations, et construire le système d'inscription aux événements comme défini dans la spécification OpenAPI (`/events/{id}/join`). Cela inclut la création des modèles de base de données nécessaires, la logique de repository pour les opérations CRUD, et les endpoints pour que les utilisateurs puissent s'inscrire aux événements et que les organisateurs puissent voir les participants.
-*   **Livrables:** `event-service` entièrement persistant, fonctionnalité d'inscription aux événements, couverture de test complète.
-*   **Issue Associée:** `decarvalhoe/meetinity-event-service#1`
+### Tâche 4.2 – Intégrations clients
+- **Description :** Brancher l'application mobile et le portail admin sur les nouveaux endpoints de messagerie avec notifications en temps réel.
+- **Livrables :** Guides d'intégration, stories UI, scénarios de tests bout-en-bout couvrant un échange de messages.
 
-### Tâche 2.2: Compléter le Matching Service avec Swipe et Matching en Temps Réel
+---
 
-*   **Description:** Implémenter la fonctionnalité de swipe (`/swipe` endpoint) pour enregistrer les "likes" et "passes" des utilisateurs. Développer un système de détection de match en temps réel, potentiellement en utilisant des WebSockets ou une file d'attente de messages (comme Kafka), pour notifier immédiatement les utilisateurs lorsqu'un match mutuel se produit. Cela nécessite une intégration complète avec le `user-service` pour récupérer les profils pour l'algorithme de matching.
-*   **Livrables:** API de swipe fonctionnelle, système de notification de match en temps réel, intégration avec le `user-service`.
-*   **Issue Associée:** `decarvalhoe/meetinity-matching-service#1`
-
-## EPIC 3: Implémenter les Fonctionnalités de Réseautage de l'Application Mobile
-
-Cet épique se concentre sur la construction des fonctionnalités de base de l'application mobile qui permettent aux utilisateurs d'interagir et de se connecter.
-
-### Tâche 3.1: Construire l'Interface de Découverte de Profils et de Swipe
-
-*   **Description:** Créer la fonctionnalité principale de l'application pour la découverte d'autres professionnels. Cela implique la construction de l'écran "Découverte" qui récupère les profils du `matching-service`, les affiche dans une interface utilisateur basée sur des cartes (similaire à Tinder), et permet aux utilisateurs de swiper à gauche (passer) ou à droite (aimer). La gestion de l'état doit être robuste pour gérer efficacement le chargement des profils, les animations de swipe et les appels API.
-*   **Livrables:** Écran "Découverte" avec des cartes de profil, implémentation du geste de swipe, intégration de l'API avec le `matching-service`.
-*   **Issue Associée:** `decarvalhoe/meetinity-mobile-app#4`
-
-### Tâche 3.2: Implémenter le Système de Matchs et de Messagerie
-
-*   **Description:** Créer un écran "Matchs" qui affiche une liste des utilisateurs avec lesquels un match mutuel a été établi. À partir de cet écran, les utilisateurs devraient pouvoir entamer une conversation. Cela nécessite la construction d'une interface de messagerie complète, y compris un écran de liste de conversations et un écran de chat pour l'échange de messages en temps réel, en utilisant les endpoints définis dans la spécification OpenAPI (`/conversations`, `/messages`).
-*   **Livrables:** Écran "Matchs", écran de liste de conversations, interface de chat en temps réel.
-*   **Issue Associée:** `decarvalhoe/meetinity-mobile-app#4`
-
-## EPIC 4: Améliorer l'API Gateway et le Portail d'Administration
-
-Cet épique vise à ajouter des fonctionnalités avancées à l'API Gateway et à étendre les capacités du portail d'administration.
-
-### Tâche 4.1: Implémenter des Fonctionnalités Avancées pour l'API Gateway
-
-*   **Description:** Améliorer l'API Gateway en ajoutant des fonctionnalités critiques prêtes pour la production. Cela inclut l'implémentation de la limitation de débit (rate limiting) pour prévenir les abus, l'ajout d'une couche de cache (par exemple, avec Redis) pour les données fréquemment consultées et non sensibles, et l'implémentation d'une journalisation structurée (par exemple, au format JSON) pour une meilleure surveillance et analyse.
-*   **Livrables:** Middleware de limitation de débit, mécanisme de mise en cache, implémentation de la journalisation structurée.
-*   **Issue Associée:** `decarvalhoe/meetinity-api-gateway#4`
-
-### Tâche 4.2: Étendre le Portail d'Administration avec la Gestion des Événements et du Contenu
-
-*   **Description:** Étendre le portail d'administration au-delà de la gestion des utilisateurs. Construire des modules pour la gestion des événements (voir, modifier, supprimer) et pour la modération de contenu (par exemple, examiner les profils ou les messages signalés). Cela implique la création de nouveaux composants, services et routes au sein de l'application React.
-*   **Livrables:** Tableau de bord de gestion des événements, outils de modération de contenu dans le portail d'administration.
-*   **Issue Associée:** `decarvalhoe/meetinity-admin-portal#4`
-
-## EPIC 5: Finaliser la Documentation et les Tests
-
-Cet épique se concentre sur l'amélioration de la qualité globale du projet par le biais de tests approfondis et d'une documentation complète.
-
-### Tâche 5.1: Atteindre une Couverture de Test Élevée sur Tous les Services
-
-*   **Description:** Augmenter systématiquement la couverture des tests pour tous les microservices et les applications frontend. Cela inclut la rédaction de tests unitaires pour les fonctions et composants individuels, et de tests d'intégration pour les interactions entre services et les endpoints de l'API. L'objectif est d'atteindre un niveau de couverture élevé (par exemple, >80%) pour garantir la qualité du code et prévenir les régressions.
-*   **Livrables:** Rapports de couverture de test améliorés, nouvelles suites de tests pour tous les repositories.
-
-### Tâche 5.2: Générer une Documentation Complète de l'API et du Projet
-
-*   **Description:** Créer un hub de documentation centralisé. Générer automatiquement la documentation de l'API à partir de la spécification OpenAPI et l'héberger. Rédiger des guides détaillés pour les développeurs sur des sujets tels que la configuration locale, l'architecture et les directives de contribution. S'assurer que le `README.md` de chaque repository est à jour et fournit des instructions claires.
-*   **Livrables:** Documentation de l'API hébergée, guides complets pour les développeurs, READMEs mis à jour.
-
+Les tâches hors périmètre MVP (améliorations UI secondaires, optimisations financières cloud, refontes d'infrastructure déjà livrées) sont volontairement écartées afin de concentrer l'équipe sur l'ouverture du produit aux premiers utilisateurs.

--- a/docs/project-evaluation.md
+++ b/docs/project-evaluation.md
@@ -1,35 +1,33 @@
-# Évaluation du Projet Meetinity
+# Évaluation du Projet Meetinity – Septembre 2025
 
 ## 1. Vue d'ensemble
 
-Ce repository sert de point d'entrée principal pour le projet Meetinity. Il contient la documentation de l'architecture, les spécifications OpenAPI, et les workflows d'intégration et de déploiement continus (CI/CD).
+Le repository principal consolide désormais la documentation fonctionnelle, les contrats d'API et l'infrastructure commune aux microservices. Les travaux livrés au cours du dernier trimestre ont permis d'industrialiser l'intégration continue, d'automatiser le provisionnement cloud et de standardiser la containerisation de l'ensemble des services.
 
-## 2. État Actuel
+## 2. Réalisations Clés
 
-Le repository est bien structuré et fournit une base solide pour le développement de la plateforme. Les workflows CI/CD sont définis, mais nécessitent une configuration complète pour être opérationnels. Les contrats d'API (OpenAPI) sont également présents, ce qui est essentiel pour la communication entre les microservices.
+- **CI/CD opérationnel** : Les workflows GitHub Actions exécutent les tests, publient les images conteneurisées et orchestrent les promotions vers les environnements de staging et de production.
+- **Infrastructure as Code** : Les modules Terraform, les chartes Helm et les manifestes Kubernetes décrits dans le dossier `infra/` forment une base reproductible couvrant réseau, sécurité, base de données Aurora et observabilité.
+- **Standardisation de la containerisation** : Les images Docker pour les services backend et les frontends suivent une même convention de build, documentée dans [`docs/containerization-roadmap.md`](containerization-roadmap.md) et [`docs/cloud-operations.md`](cloud-operations.md).
 
-### Points Forts
+Ces livrables rendent l'infrastructure testable et déployable de bout en bout, réduisant drastiquement le travail manuel pour chaque nouvelle fonctionnalité.
 
-- **Architecture Microservices :** L'architecture est clairement définie et modulaire.
-- **Contrats d'API :** La présence de spécifications OpenAPI facilite le développement et l'intégration des services.
-- **Automatisation :** Les bases pour l'automatisation CI/CD sont en place.
+## 3. Lacunes Fonctionnelles
 
-### Points à Améliorer
+Malgré ces avancées, plusieurs fonctionnalités essentielles à la valeur utilisateur restent incomplètes :
 
-- **Infrastructure de Déploiement :** L'infrastructure de déploiement n'est pas encore complètement définie ni mise en œuvre.
-- **Documentation d'Architecture :** La documentation d'architecture pourrait être plus détaillée pour inclure des diagrammes et des descriptions plus approfondies des interactions entre les services.
+- **Couverture de l'API Gateway** : La passerelle gère l'authentification mais n'expose pas encore l'ensemble des flux événements, matching et messagerie.
+- **Inscriptions aux événements** : Le `event-service` ne persiste pas les inscriptions et n'émet pas les notifications nécessaires.
+- **Synchronisation des données de matching** : Le `matching-service` fonctionne avec des données fictives et n'est pas raccordé aux profils ni aux disponibilités d'événements.
+- **Messagerie temps réel** : Aucun service de conversation n'est encore prêt, et les applications clientes n'ont pas de canal de communication actif.
 
-## 3. Issues Ouvertes
+Ces éléments constituent le cœur de l'expérience Meetinity et expliquent la progression limitée sur les indicateurs métiers.
 
-Les issues ouvertes dans ce repository sont de nature stratégique et architecturale :
+## 4. Recommandations Prioritaires
 
-- **[STRATEGY] Data Architecture and Integration Strategy (#3) :** Définir une stratégie claire pour l'architecture des données et l'intégration entre les services.
-- **[ARCHITECTURE] New Microservices Implementation (#2) :** Planifier l'implémentation de nouveaux microservices.
-- **[INFRASTRUCTURE] Complete DevOps and Deployment Infrastructure (#1) :** Finaliser l'infrastructure DevOps et de déploiement.
+1. **Étendre la Gateway** pour couvrir les flux d'événements, de matching et de messagerie, avec journalisation et observabilité alignées sur les normes définies.
+2. **Finaliser les inscriptions** en connectant le `event-service` à PostgreSQL, en implémentant la logique de places disponibles et en publiant des événements de domaine.
+3. **Boucler la synchronisation Matching** en orchestrant les échanges entre `user-service`, `event-service` et `matching-service`, avec des jobs de mise à jour et une file d'attente évènementielle.
+4. **Livrer la Messagerie MVP** en choisissant la pile (ex. WebSocket + Redis streams), en exposant les endpoints REST/WebSocket, puis en intégrant le mobile et l'admin.
 
-## 4. Recommandations
-
-- **Prioriser l'Infrastructure :** Il est crucial de finaliser l'infrastructure de déploiement pour permettre des tests et des déploiements automatisés.
-- **Détailler l'Architecture des Données :** Une documentation détaillée de l'architecture des données est nécessaire pour assurer la cohérence et l'intégrité des données à travers la plateforme.
-- **Décomposer les Épiques :** Les issues de type "EPIC" devraient être décomposées en tâches plus petites et plus faciles à gérer pour une meilleure planification et un meilleur suivi.
-
+La base d'infrastructure permet désormais de se concentrer exclusivement sur ces blocs fonctionnels pour atteindre un MVP cohérent.


### PR DESCRIPTION
## Summary
- update README to point to the consolidated services directory, refresh progress tracking, and surface new infrastructure documentation
- rewrite the project evaluation to highlight delivered CI/CD, Terraform, and containerization work while calling out remaining functional gaps
- reprioritize the TODO list around API gateway coverage, event registrations, matching data sync, and messaging for the MVP

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68da18923ff883329856046745387535