### PR TITLE
Add analytics service and warehouse infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,28 @@ jobs:
       - name: Run integration suite
         run: pytest -m integration tests/integration -vv
 
+  analytics-tests:
+    name: Analytics Service Tests
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/analytics-service
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt pytest
+
+      - name: Run unit tests
+        run: pytest -vv
+
   security_scan:
     name: Security Scan
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 # Helm dependency archives
 infra/helm/meetinity/charts/*.tgz
 infra/helm/meetinity/charts/*/charts/*.tgz
+
+# Local analytics service artefacts
+services/analytics-service/*.db
+services/analytics-service/.pytest_cache/
+services/analytics-service/.venv/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -122,6 +122,8 @@ services:
       FLASK_DEBUG: "1"
       PORT: 8080
       PYTHONUNBUFFERED: "1"
+      ANALYTICS_SERVICE_URL: http://analytics-service:8080
+      RATE_LIMIT_ANALYTICS: "10/minute"
     command: >
       sh -c "flask run --debug --host=0.0.0.0 --port 8080"
     volumes:
@@ -214,6 +216,35 @@ services:
       sh -c "alembic upgrade head && flask run --debug --host=0.0.0.0 --port 8080"
     volumes:
       - ./services/event-service:/app
+    networks:
+      - meetinity-net
+
+  analytics-service:
+    build:
+      context: ./services/analytics-service
+      dockerfile: Dockerfile
+    container_name: meetinity-analytics-service
+    restart: unless-stopped
+    env_file:
+      - .env.dev
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    ports:
+      - "${ANALYTICS_SERVICE_PORT:-8086}:8080"
+    environment:
+      FLASK_APP: src.main:create_app
+      FLASK_RUN_HOST: 0.0.0.0
+      FLASK_RUN_PORT: 8080
+      FLASK_DEBUG: "1"
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-meetinity}:${POSTGRES_PASSWORD:-meetinity}@postgres:5432/${POSTGRES_DB:-meetinity}?options=-csearch_path%3Danalytics
+      PYTHONUNBUFFERED: "1"
+    command: >
+      sh -c "flask run --debug --host=0.0.0.0 --port 8080"
+    volumes:
+      - ./services/analytics-service:/app
     networks:
       - meetinity-net
 

--- a/infra/helm/meetinity/values.yaml
+++ b/infra/helm/meetinity/values.yaml
@@ -89,6 +89,130 @@ shared:
       data:
         FEATURE_FLAGS: "false"
         DEFAULT_TIMEZONE: "UTC"
+    analytics-dashboard:
+      labels:
+        grafana_dashboard: "1"
+      data:
+        analytics-overview.json: |
+          {
+            "annotations": {
+              "list": [
+                {
+                  "builtIn": 1,
+                  "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+                  "enable": true,
+                  "hide": true,
+                  "iconColor": "rgba(0, 211, 255, 1)",
+                  "name": "Annotations & Alerts",
+                  "type": "dashboard"
+                }
+              ]
+            },
+            "editable": true,
+            "graphTooltip": 0,
+            "panels": [
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "fieldConfig": {
+                  "defaults": { "unit": "ops" },
+                  "overrides": []
+                },
+                "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+                "targets": [
+                  {
+                    "expr": "sum(rate(analytics_events_ingested_total[5m]))",
+                    "legendFormat": "events/min",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Events Ingested",
+                "type": "timeseries"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "fieldConfig": {
+                  "defaults": { "unit": "s" },
+                  "overrides": []
+                },
+                "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+                "targets": [
+                  {
+                    "expr": "histogram_quantile(0.95, sum(rate(analytics_event_ingest_latency_seconds_bucket[5m])) by (le))",
+                    "legendFormat": "latency",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Ingestion Latency (p95)",
+                "type": "timeseries"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "fieldConfig": {
+                  "defaults": {
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        { "color": "green", "value": null },
+                        { "color": "orange", "value": 1800 },
+                        { "color": "red", "value": 3600 }
+                      ]
+                    },
+                    "unit": "s"
+                  },
+                  "overrides": []
+                },
+                "gridPos": { "h": 6, "w": 6, "x": 0, "y": 8 },
+                "options": {
+                  "reduceOptions": {
+                    "calcs": ["lastNotNull"],
+                    "fields": "",
+                    "values": false
+                  }
+                },
+                "targets": [
+                  {
+                    "expr": "time() - analytics_warehouse_last_success_epoch",
+                    "legendFormat": "age",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Last Warehouse Refresh",
+                "type": "stat"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "fieldConfig": {
+                  "defaults": { "unit": "short" },
+                  "overrides": []
+                },
+                "gridPos": { "h": 6, "w": 6, "x": 6, "y": 8 },
+                "options": {
+                  "reduceOptions": {
+                    "calcs": ["lastNotNull"],
+                    "fields": "",
+                    "values": false
+                  }
+                },
+                "targets": [
+                  {
+                    "expr": "increase(analytics_warehouse_rows_total[24h])",
+                    "legendFormat": "rows",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Warehouse Rows Materialised",
+                "type": "stat"
+              }
+            ],
+            "refresh": "5m",
+            "schemaVersion": 38,
+            "style": "dark",
+            "tags": ["analytics"],
+            "templating": { "list": [] },
+            "time": { "from": "now-24h", "to": "now" },
+            "timepicker": {},
+            "timezone": ""
+          }
   sealedSecrets: []
   vaultSecrets:
     - name: shared-database

--- a/infra/monitoring/grafana/dashboards/analytics-overview.json
+++ b/infra/monitoring/grafana/dashboards/analytics-overview.json
@@ -1,0 +1,126 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Events Ingested",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(analytics_events_ingested_total[5m]))",
+          "legendFormat": "events/min",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingestion Latency (p95)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(analytics_event_ingest_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "latency",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "type": "stat",
+      "title": "Last Warehouse Refresh",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "time() - analytics_warehouse_last_success_epoch",
+          "legendFormat": "age",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1800 },
+              { "color": "red", "value": 3600 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 8 }
+    },
+    {
+      "type": "stat",
+      "title": "Warehouse Rows Materialised",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "increase(analytics_warehouse_rows_total[24h])",
+          "legendFormat": "rows",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 8 }
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["analytics"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": ""
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -124,6 +124,27 @@ module "redis" {
   tags                       = local.default_tags
 }
 
+module "analytics_warehouse" {
+  source = "./modules/redshift"
+
+  count                      = var.analytics_warehouse_config.enabled ? 1 : 0
+  name                       = "${var.environment}-${var.analytics_warehouse_config.name}"
+  database_name              = var.analytics_warehouse_config.database_name
+  master_username            = var.analytics_warehouse_config.master_username
+  node_type                  = var.analytics_warehouse_config.node_type
+  number_of_nodes            = var.analytics_warehouse_config.number_of_nodes
+  port                       = var.analytics_warehouse_config.port
+  snapshot_retention         = var.analytics_warehouse_config.snapshot_retention
+  maintenance_window         = var.analytics_warehouse_config.maintenance_window
+  subnet_ids                 = module.vpc.private_subnet_ids
+  vpc_security_group_ids     = distinct(concat(var.analytics_warehouse_config.allowed_security_group_ids, [
+    module.eks.node_security_group_id,
+    module.eks.cluster_security_group_id,
+  ]))
+  kms_key_id                 = try(var.analytics_warehouse_config.kms_key_id, null)
+  tags                       = local.default_tags
+}
+
 module "static_assets" {
   source = "./modules/cdn"
 

--- a/infra/terraform/modules/redshift/main.tf
+++ b/infra/terraform/modules/redshift/main.tf
@@ -1,0 +1,29 @@
+resource "random_password" "master" {
+  length  = var.master_password_length
+  special = true
+}
+
+resource "aws_redshift_subnet_group" "this" {
+  name       = "${var.name}-subnet-group"
+  subnet_ids = var.subnet_ids
+  tags       = var.tags
+}
+
+resource "aws_redshift_cluster" "this" {
+  cluster_identifier                  = var.name
+  database_name                       = var.database_name
+  master_username                     = var.master_username
+  master_password                     = random_password.master.result
+  node_type                           = var.node_type
+  number_of_nodes                     = var.number_of_nodes
+  port                                = var.port
+  cluster_subnet_group_name           = aws_redshift_subnet_group.this.name
+  vpc_security_group_ids              = var.vpc_security_group_ids
+  automated_snapshot_retention_period = var.snapshot_retention
+  preferred_maintenance_window        = var.maintenance_window
+  publicly_accessible                 = false
+  encrypted                           = true
+  skip_final_snapshot                 = false
+  tags                                = var.tags
+  kms_key_id                          = var.kms_key_id != "" ? var.kms_key_id : null
+}

--- a/infra/terraform/modules/redshift/outputs.tf
+++ b/infra/terraform/modules/redshift/outputs.tf
@@ -1,0 +1,30 @@
+output "cluster_identifier" {
+  value       = aws_redshift_cluster.this.id
+  description = "Identifier for the Redshift cluster"
+}
+
+output "endpoint" {
+  value       = aws_redshift_cluster.this.endpoint
+  description = "Cluster endpoint hostname"
+}
+
+output "port" {
+  value       = aws_redshift_cluster.this.port
+  description = "Port exposed by the cluster"
+}
+
+output "database_name" {
+  value       = aws_redshift_cluster.this.database_name
+  description = "Default database name"
+}
+
+output "master_username" {
+  value       = aws_redshift_cluster.this.master_username
+  description = "Master username"
+}
+
+output "master_password" {
+  value       = random_password.master.result
+  description = "Generated master password"
+  sensitive   = true
+}

--- a/infra/terraform/modules/redshift/variables.tf
+++ b/infra/terraform/modules/redshift/variables.tf
@@ -1,0 +1,75 @@
+variable "name" {
+  description = "Base name for the Redshift cluster"
+  type        = string
+}
+
+variable "database_name" {
+  description = "Primary database name"
+  type        = string
+  default     = "analytics"
+}
+
+variable "master_username" {
+  description = "Master user name for Redshift"
+  type        = string
+  default     = "analytics_admin"
+}
+
+variable "master_password_length" {
+  description = "Generated master password length"
+  type        = number
+  default     = 32
+}
+
+variable "node_type" {
+  description = "Redshift node type"
+  type        = string
+  default     = "ra3.xlplus"
+}
+
+variable "number_of_nodes" {
+  description = "Number of compute nodes"
+  type        = number
+  default     = 2
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs used by the subnet group"
+  type        = list(string)
+}
+
+variable "vpc_security_group_ids" {
+  description = "Security groups allowed to access the cluster"
+  type        = list(string)
+  default     = []
+}
+
+variable "port" {
+  description = "Port exposed by the cluster"
+  type        = number
+  default     = 5439
+}
+
+variable "snapshot_retention" {
+  description = "Number of days to retain automated snapshots"
+  type        = number
+  default     = 7
+}
+
+variable "maintenance_window" {
+  description = "Weekly maintenance window"
+  type        = string
+  default     = "sun:05:00-sun:05:30"
+}
+
+variable "kms_key_id" {
+  description = "Optional KMS key for encryption"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags applied to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -90,6 +90,21 @@ output "redis_auth_token" {
   sensitive   = true
 }
 
+output "analytics_warehouse_endpoint" {
+  description = "Endpoint of the analytics data warehouse."
+  value       = length(module.analytics_warehouse) > 0 ? module.analytics_warehouse[0].endpoint : null
+}
+
+output "analytics_warehouse_port" {
+  description = "Port exposed by the analytics data warehouse."
+  value       = length(module.analytics_warehouse) > 0 ? module.analytics_warehouse[0].port : null
+}
+
+output "analytics_warehouse_database" {
+  description = "Default database name configured for the analytics warehouse."
+  value       = length(module.analytics_warehouse) > 0 ? module.analytics_warehouse[0].database_name : null
+}
+
 output "static_assets_bucket_name" {
   description = "Name of the S3 bucket hosting static assets."
   value       = module.static_assets.bucket_name

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -183,6 +183,36 @@ variable "redis_config" {
   }
 }
 
+variable "analytics_warehouse_config" {
+  description = "Configuration for the analytics data warehouse cluster."
+  type = object({
+    enabled                    = bool
+    name                       = string
+    database_name              = string
+    master_username            = string
+    node_type                  = string
+    number_of_nodes            = number
+    port                       = number
+    snapshot_retention         = number
+    maintenance_window         = string
+    allowed_security_group_ids = list(string)
+    kms_key_id                 = optional(string)
+  })
+  default = {
+    enabled                    = true
+    name                       = "analytics-warehouse"
+    database_name              = "analytics"
+    master_username            = "analytics_admin"
+    node_type                  = "ra3.xlplus"
+    number_of_nodes            = 2
+    port                       = 5439
+    snapshot_retention         = 7
+    maintenance_window         = "sun:05:00-sun:05:30"
+    allowed_security_group_ids = []
+    kms_key_id                 = null
+  }
+}
+
 variable "waf_config" {
   description = "Configuration for the AWS WAF web ACL protecting the ingress load balancer."
   type = object({

--- a/services/analytics-service/Dockerfile
+++ b/services/analytics-service/Dockerfile
@@ -1,0 +1,52 @@
+# Multi-stage build for Meetinity Analytics Service
+FROM python:3.11-slim as builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+FROM python:3.11-slim as runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN groupadd -r meetinity && useradd -r -g meetinity -s /bin/bash meetinity
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /app
+
+COPY --chown=meetinity:meetinity . .
+
+RUN mkdir -p /app/logs && \
+    chown -R meetinity:meetinity /app
+
+USER meetinity
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+ENV PYTHONPATH=/app \
+    PYTHONUNBUFFERED=1 \
+    FLASK_APP=src.main:create_app \
+    APP_PORT=8080
+
+CMD ["python", "-m", "gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "120", "src.main:create_app()"]

--- a/services/analytics-service/README.md
+++ b/services/analytics-service/README.md
@@ -1,0 +1,29 @@
+# Meetinity Analytics Service
+
+The analytics service centralises user and product telemetry, persists canonical
+analytics events, and materialises business KPIs for downstream reporting. It
+provides synchronous ingestion endpoints, asynchronous consumers, and REST
+reporting APIs that expose the warehouse views consumed by dashboards.
+
+## Features
+
+- **Ingestion endpoints** – `/ingest/events` and `/ingest/batch` accept
+  canonical events, enforce schema validation, and record Prometheus metrics.
+- **Message consumers** – `AnalyticsEventConsumer` parses Kafka-style payloads
+  to reuse the same ingestion pipeline for streaming sources.
+- **Warehouse rollups** – the `WarehouseLoader` computes daily aggregates and
+  stores KPI snapshots in the warehouse tables.
+- **Reporting APIs** – `/reports/kpis` and `/reports/refresh` expose KPI
+  snapshots and manual backfill triggers for operators.
+- **Metadata catalog** – `/metadata/schemas` and `/metadata/kpis` document the
+  available event schemas and KPI definitions for producers and analysts.
+
+## Local development
+
+```bash
+pip install -r requirements.txt
+FLASK_APP=src.main:create_app flask run --reload
+```
+
+Refer to [`docs/SCHEMAS.md`](docs/SCHEMAS.md) for the canonical event schema and
+[`docs/KPIS.md`](docs/KPIS.md) for KPI definitions and SLIs.

--- a/services/analytics-service/docs/KPIS.md
+++ b/services/analytics-service/docs/KPIS.md
@@ -1,0 +1,20 @@
+# KPI Catalogue
+
+| KPI | Description | Calculation |
+| --- | ----------- | ----------- |
+| `events.total` | Total number of analytics events per day. | Count of `analytics_events` grouped by day. |
+| `users.daily_active` | Distinct users generating at least one event in the day. | Count of distinct `user_id` across all event types. |
+| `funnel.booking_conversion` | Booking funnel conversion rate. | `booking.completed` / `booking.started` for the day. |
+
+## Data Retention
+
+Raw events are retained for 90 days in the operational store before archival.
+Warehouse snapshots are kept indefinitely to support long term reporting.
+
+## SLOs and SLIs
+
+- **Ingestion latency** – 95% of events are available in the warehouse within 5
+  minutes of occurrence (`analytics_event_ingest_latency_seconds`).
+- **Warehouse freshness** – The last successful rollup timestamp
+  (`analytics_warehouse_last_success_epoch`) must be less than 30 minutes old
+  during business hours.

--- a/services/analytics-service/docs/SCHEMAS.md
+++ b/services/analytics-service/docs/SCHEMAS.md
@@ -1,0 +1,22 @@
+# Analytics Event Schemas
+
+## Canonical Event Envelope
+
+| Field        | Type    | Description |
+| ------------ | ------- | ----------- |
+| `event_type` | string  | Canonical name of the event (e.g. `booking.started`). |
+| `user_id`    | string? | Optional user identifier for authenticated events. |
+| `occurred_at`| string  | ISO-8601 timestamp when the action happened. |
+| `ingestion_id` | string? | Optional idempotency key supplied by producers to deduplicate events. |
+| `source`     | string  | Origin transport (`http`, `kafka`, `webhook`). |
+| `payload`    | object  | Free-form JSON payload describing the event. |
+| `context`    | object  | Optional metadata such as device, locale, experiment IDs. |
+
+### Common Event Types
+
+- `booking.started` – triggered when a user initiates a meeting booking workflow.
+- `booking.completed` – emitted once the booking is confirmed.
+- `session.active` – emitted every five minutes while the user remains active.
+
+All event producers must publish envelopes that comply with the schema above to
+ensure consistent ingestion and downstream warehousing.

--- a/services/analytics-service/requirements.txt
+++ b/services/analytics-service/requirements.txt
@@ -1,0 +1,5 @@
+Flask==2.3.3
+SQLAlchemy==2.0.23
+pydantic==1.10.14
+prometheus-client==0.17.1
+psycopg[binary]==3.1.12

--- a/services/analytics-service/src/config.py
+++ b/services/analytics-service/src/config.py
@@ -1,0 +1,65 @@
+"""Configuration helpers for the analytics service."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+import os
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    """Runtime configuration resolved from environment variables."""
+
+    database_url: str
+    warehouse_url: str | None
+    ingestion_topic: str
+    warehouse_rollup_minutes: int
+    retention_days: int
+    enable_metrics: bool = True
+
+    @property
+    def rollup_interval(self) -> timedelta:
+        return timedelta(minutes=self.warehouse_rollup_minutes)
+
+
+def _env(key: str, default: str | None = None) -> str | None:
+    value = os.getenv(key)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def _parse_bool(value: Any, default: bool = True) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return default
+
+
+def load_config(overrides: dict[str, Any] | None = None) -> AppConfig:
+    """Load configuration from environment variables and optional overrides."""
+
+    overrides = overrides or {}
+    database_url = str(overrides.get("DATABASE_URL") or _env("DATABASE_URL") or "sqlite:///./analytics.db")
+    warehouse_url = overrides.get("WAREHOUSE_URL") or _env("WAREHOUSE_URL")
+    ingestion_topic = str(overrides.get("INGESTION_TOPIC") or _env("INGESTION_TOPIC") or "analytics.events")
+    rollup_minutes_raw = overrides.get("WAREHOUSE_ROLLUP_MINUTES") or _env("WAREHOUSE_ROLLUP_MINUTES", "60") or 60
+    retention_days_raw = overrides.get("EVENT_RETENTION_DAYS") or _env("EVENT_RETENTION_DAYS", "90") or 90
+    rollup_minutes = int(rollup_minutes_raw)
+    retention_days = int(retention_days_raw)
+    enable_metrics = _parse_bool(overrides.get("ENABLE_METRICS", _env("ENABLE_METRICS")))
+
+    return AppConfig(
+        database_url=database_url,
+        warehouse_url=str(warehouse_url) if warehouse_url else None,
+        ingestion_topic=ingestion_topic,
+        warehouse_rollup_minutes=rollup_minutes,
+        retention_days=retention_days,
+        enable_metrics=enable_metrics,
+    )

--- a/services/analytics-service/src/consumers.py
+++ b/services/analytics-service/src/consumers.py
@@ -1,0 +1,41 @@
+"""Event consumers for asynchronous ingestion."""
+from __future__ import annotations
+
+import json
+from typing import Iterable, Mapping
+
+from sqlalchemy.orm import Session
+
+from . import schemas
+from .services.ingestion import IngestionService
+
+
+class AnalyticsEventConsumer:
+    """Consume events from a message queue and persist them."""
+
+    def __init__(self, session: Session):
+        self._ingestion = IngestionService(session)
+
+    def _parse(self, message: Mapping[str, object]) -> schemas.EventPayload:
+        if "payload" in message and isinstance(message["payload"], str):
+            try:
+                body = json.loads(message["payload"])
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise ValueError("payload is not valid JSON") from exc
+        else:
+            body = message
+        return schemas.EventPayload(**body)  # type: ignore[arg-type]
+
+    def consume(self, message: Mapping[str, object]) -> int:
+        payload = self._parse(message)
+        self._ingestion.ingest(payload)
+        return 1
+
+    def consume_batch(self, messages: Iterable[Mapping[str, object]]) -> int:
+        count = 0
+        for message in messages:
+            count += self.consume(message)
+        return count
+
+
+__all__ = ["AnalyticsEventConsumer"]

--- a/services/analytics-service/src/database.py
+++ b/services/analytics-service/src/database.py
@@ -1,0 +1,72 @@
+"""Database helpers for the analytics service."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from .models import Base
+
+
+_engine: Engine | None = None
+_Session = None
+
+
+def init_engine(database_url: str) -> Engine:
+    """Initialise the SQLAlchemy engine and session factory."""
+
+    global _engine, _Session
+
+    if _engine is not None:
+        _engine.dispose()
+
+    kwargs: dict[str, object] = {"future": True, "pool_pre_ping": True}
+    if database_url.startswith("sqlite"):  # pragma: no cover - configuration branch
+        kwargs.setdefault("connect_args", {"check_same_thread": False})
+        kwargs.setdefault("poolclass", StaticPool)
+
+    _engine = create_engine(database_url, **kwargs)
+    _Session = scoped_session(
+        sessionmaker(bind=_engine, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
+    )
+    Base.metadata.create_all(_engine)
+    return _engine
+
+
+def get_engine() -> Engine:
+    if _engine is None:
+        raise RuntimeError("Database engine not initialised. Call init_engine() first.")
+    return _engine
+
+
+def get_session():
+    if _Session is None:
+        raise RuntimeError("Session factory not initialised. Call init_engine() first.")
+    return _Session()
+
+
+@contextmanager
+def session_scope() -> Generator:
+    session = get_session()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def dispose_engine() -> None:
+    global _engine, _Session
+    if _Session is not None:
+        _Session.remove()
+    if _engine is not None:
+        _engine.dispose()
+    _engine = None
+    _Session = None

--- a/services/analytics-service/src/main.py
+++ b/services/analytics-service/src/main.py
@@ -1,0 +1,48 @@
+"""Application entrypoint for the analytics service."""
+from __future__ import annotations
+
+from flask import Flask, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from .config import load_config
+from .database import dispose_engine, init_engine
+from .routes import register_blueprints
+from .routes.dependencies import cleanup_services
+
+
+def create_app(config_overrides: dict[str, object] | None = None) -> Flask:
+    config = load_config(config_overrides)
+    app = Flask(__name__)
+    app.config.update(
+        {
+            "DATABASE_URL": config.database_url,
+            "WAREHOUSE_URL": config.warehouse_url,
+            "WAREHOUSE_ROLLUP_MINUTES": config.warehouse_rollup_minutes,
+            "EVENT_RETENTION_DAYS": config.retention_days,
+            "ENABLE_METRICS": config.enable_metrics,
+        }
+    )
+
+    init_engine(config.database_url)
+    register_blueprints(app)
+    app.teardown_appcontext(cleanup_services)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok", "service": "analytics-service"}
+
+    @app.get("/metrics")
+    def metrics() -> Response:
+        if not config.enable_metrics:
+            return Response("", mimetype=CONTENT_TYPE_LATEST)
+        payload = generate_latest()
+        return Response(payload, mimetype=CONTENT_TYPE_LATEST)
+
+    return app
+
+
+def shutdown() -> None:
+    dispose_engine()
+
+
+app = create_app()

--- a/services/analytics-service/src/metrics.py
+++ b/services/analytics-service/src/metrics.py
@@ -1,0 +1,57 @@
+"""Prometheus metrics exported by the analytics service."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from time import time
+from typing import Iterator
+
+from prometheus_client import Counter, Gauge, Histogram
+
+EVENTS_INGESTED = Counter(
+    "analytics_events_ingested_total",
+    "Number of events accepted by the ingestion API",
+    labelnames=("source", "event_type"),
+)
+
+EVENT_INGEST_LATENCY = Histogram(
+    "analytics_event_ingest_latency_seconds",
+    "Latency between event occurrence and ingestion",
+    buckets=(0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300),
+)
+
+WAREHOUSE_LOAD_DURATION = Histogram(
+    "analytics_warehouse_load_duration_seconds",
+    "Duration of warehouse rollup batches",
+)
+
+WAREHOUSE_ROWS = Counter(
+    "analytics_warehouse_rows_total",
+    "Rows materialised into the warehouse",
+    labelnames=("table",),
+)
+
+WAREHOUSE_STATUS = Gauge(
+    "analytics_warehouse_last_success_epoch",
+    "Unix timestamp of the last successful warehouse rollup",
+)
+
+
+def observe_ingestion(event_type: str, source: str, latency_seconds: float) -> None:
+    EVENTS_INGESTED.labels(source=source, event_type=event_type).inc()
+    EVENT_INGEST_LATENCY.observe(latency_seconds)
+
+
+@contextmanager
+def record_warehouse_batch(table: str) -> Iterator[None]:
+    start = time()
+    try:
+        yield
+    finally:
+        duration = max(time() - start, 0.0)
+        WAREHOUSE_LOAD_DURATION.observe(duration)
+        WAREHOUSE_STATUS.set(time())
+
+
+def observe_rows_materialised(table: str, count: int) -> None:
+    if count:
+        WAREHOUSE_ROWS.labels(table=table).inc(count)

--- a/services/analytics-service/src/models.py
+++ b/services/analytics-service/src/models.py
@@ -1,0 +1,80 @@
+"""SQLAlchemy models for analytics data."""
+from __future__ import annotations
+
+from datetime import datetime, date
+from typing import Any
+
+from sqlalchemy import Column, Date, DateTime, Float, Integer, JSON, String, Text, UniqueConstraint, Index
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+
+class AnalyticsEvent(Base):
+    __tablename__ = "analytics_events"
+    __table_args__ = (
+        Index("ix_analytics_events_type_time", "event_type", "occurred_at"),
+        Index("ix_analytics_events_user_time", "user_id", "occurred_at"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    event_type = Column(String(120), nullable=False)
+    user_id = Column(String(64), nullable=True)
+    occurred_at = Column(DateTime(timezone=True), nullable=False)
+    received_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    ingestion_id = Column(String(64), nullable=True)
+    source = Column(String(64), nullable=False, default="http")
+    payload = Column(JSON, nullable=False, default=dict)
+    context = Column(JSON, nullable=True)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "event_type": self.event_type,
+            "user_id": self.user_id,
+            "occurred_at": self.occurred_at.isoformat(),
+            "received_at": self.received_at.isoformat(),
+            "ingestion_id": self.ingestion_id,
+            "source": self.source,
+            "payload": self.payload,
+            "context": self.context,
+        }
+
+
+class WarehouseLoad(Base):
+    __tablename__ = "analytics_warehouse_loads"
+
+    id = Column(Integer, primary_key=True)
+    batch_id = Column(String(64), unique=True, nullable=False)
+    started_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    status = Column(String(32), nullable=False, default="running")
+    row_count = Column(Integer, nullable=False, default=0)
+    destination_table = Column(String(120), nullable=False, default="kpi_snapshots")
+    error_message = Column(Text, nullable=True)
+
+
+class KpiSnapshot(Base):
+    __tablename__ = "analytics_kpi_snapshots"
+    __table_args__ = (
+        UniqueConstraint("kpi_name", "window_start", name="ux_kpi_window"),
+        Index("ix_kpi_window", "window_start"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    kpi_name = Column(String(120), nullable=False)
+    window_start = Column(Date, nullable=False)
+    window_end = Column(Date, nullable=False)
+    value = Column(Float, nullable=False)
+    attributes = Column("metadata", JSON, nullable=True)
+    computed_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "kpi_name": self.kpi_name,
+            "window_start": self.window_start.isoformat(),
+            "window_end": self.window_end.isoformat(),
+            "value": self.value,
+            "metadata": self.attributes,
+            "computed_at": self.computed_at.isoformat(),
+        }

--- a/services/analytics-service/src/routes/__init__.py
+++ b/services/analytics-service/src/routes/__init__.py
@@ -1,0 +1,14 @@
+"""Route registration helpers."""
+from __future__ import annotations
+
+from flask import Blueprint, Flask
+
+from .ingestion import ingestion_bp
+from .metadata import metadata_bp
+from .reporting import reporting_bp
+
+
+def register_blueprints(app: Flask) -> None:
+    app.register_blueprint(ingestion_bp, url_prefix="/ingest")
+    app.register_blueprint(reporting_bp, url_prefix="/reports")
+    app.register_blueprint(metadata_bp, url_prefix="/metadata")

--- a/services/analytics-service/src/routes/dependencies.py
+++ b/services/analytics-service/src/routes/dependencies.py
@@ -1,0 +1,32 @@
+"""Request scoped dependencies."""
+from __future__ import annotations
+
+from flask import g
+
+from ..database import get_session
+from ..services.ingestion import IngestionService
+from ..services.reporting import ReportingService
+
+
+def get_ingestion_service() -> IngestionService:
+    if "analytics_session" not in g:
+        g.analytics_session = get_session()
+    if "ingestion_service" not in g:
+        g.ingestion_service = IngestionService(g.analytics_session)
+    return g.ingestion_service
+
+
+def get_reporting_service() -> ReportingService:
+    if "analytics_session" not in g:
+        g.analytics_session = get_session()
+    if "reporting_service" not in g:
+        g.reporting_service = ReportingService(g.analytics_session)
+    return g.reporting_service
+
+
+def cleanup_services(exception: Exception | None = None) -> None:
+    session = g.pop("analytics_session", None)
+    if session is not None:
+        session.close()
+    g.pop("ingestion_service", None)
+    g.pop("reporting_service", None)

--- a/services/analytics-service/src/routes/ingestion.py
+++ b/services/analytics-service/src/routes/ingestion.py
@@ -1,0 +1,26 @@
+"""HTTP endpoints for event ingestion."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from .. import schemas
+from .dependencies import get_ingestion_service
+
+
+ingestion_bp = Blueprint("analytics_ingestion", __name__)
+
+
+@ingestion_bp.post("/events")
+def ingest_event():
+    payload = schemas.EventPayload(**request.get_json(force=True))
+    service = get_ingestion_service()
+    event = service.ingest(payload)
+    return jsonify({"id": event.id, "event_type": event.event_type, "received_at": event.received_at.isoformat()}), 201
+
+
+@ingestion_bp.post("/batch")
+def ingest_batch():
+    payload = schemas.BatchIngestRequest(**request.get_json(force=True))
+    service = get_ingestion_service()
+    events = service.ingest_batch(payload.events)
+    return jsonify({"ingested": len(events)})

--- a/services/analytics-service/src/routes/metadata.py
+++ b/services/analytics-service/src/routes/metadata.py
@@ -1,0 +1,42 @@
+"""Metadata endpoints exposing schemas and KPI catalog."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+
+from ..services.warehouse import DEFAULT_KPIS
+
+
+_SCHEMAS = {
+    "event": {
+        "description": "Canonical analytics event schema",
+        "fields": {
+            "event_type": "String identifier for the event name",
+            "user_id": "Optional user identifier",
+            "occurred_at": "ISO-8601 timestamp when the event occurred",
+            "ingestion_id": "Idempotency key used to deduplicate events",
+            "source": "Transport source such as http, kafka, or webhook",
+            "payload": "Free-form JSON object describing event attributes",
+            "context": "Additional metadata such as device, locale, or experiment ids",
+        },
+    }
+}
+
+_KPIS = {
+    "events.total": "Total number of events received per day",
+    "users.daily_active": "Distinct users who generated at least one event in the window",
+    "funnel.booking_conversion": "Ratio of booking.completed over booking.started events",
+}
+
+
+metadata_bp = Blueprint("analytics_metadata", __name__)
+
+
+@metadata_bp.get("/schemas")
+def list_schemas():
+    return jsonify({"schemas": _SCHEMAS})
+
+
+@metadata_bp.get("/kpis")
+def list_kpi_definitions():
+    catalog = {name: _KPIS.get(name, "") for name in DEFAULT_KPIS}
+    return jsonify({"kpis": catalog})

--- a/services/analytics-service/src/routes/reporting.py
+++ b/services/analytics-service/src/routes/reporting.py
@@ -1,0 +1,30 @@
+"""Reporting API endpoints."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from .. import schemas
+from .dependencies import get_reporting_service
+
+
+reporting_bp = Blueprint("analytics_reporting", __name__)
+
+
+@reporting_bp.get("/kpis")
+def list_kpis():
+    service = get_reporting_service()
+    params = schemas.KpiRequest(**request.args.to_dict(flat=True)) if request.args else schemas.KpiRequest()
+    snapshots = service.fetch_snapshots(
+        params.kpis or None,
+        start=params.start_date,
+        end=params.end_date,
+    )
+    return jsonify({"kpis": snapshots})
+
+
+@reporting_bp.post("/refresh")
+def refresh_kpis():
+    payload = schemas.RefreshRequest(**request.get_json(force=True))
+    service = get_reporting_service()
+    result = service.refresh(start=payload.start_date, end=payload.end_date, force=payload.force_recompute)
+    return jsonify(result)

--- a/services/analytics-service/src/schemas.py
+++ b/services/analytics-service/src/schemas.py
@@ -1,0 +1,46 @@
+"""Pydantic schemas for request validation."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class EventPayload(BaseModel):
+    event_type: str = Field(..., description="Canonical analytics event name")
+    occurred_at: datetime = Field(..., description="Event timestamp in ISO-8601 format")
+    user_id: Optional[str] = Field(None, description="User identifier when available")
+    ingestion_id: Optional[str] = Field(None, description="Idempotency key supplied by producers")
+    source: str = Field("http", description="Event source channel")
+    payload: Dict[str, Any] = Field(default_factory=dict, description="Arbitrary event attributes")
+    context: Dict[str, Any] = Field(default_factory=dict, description="Contextual metadata such as device or locale")
+
+    @validator("event_type")
+    def _normalize_event_type(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("event_type must be provided")
+        return normalized
+
+
+class BatchIngestRequest(BaseModel):
+    events: List[EventPayload]
+
+    @validator("events")
+    def _non_empty(cls, value: List[EventPayload]) -> List[EventPayload]:
+        if not value:
+            raise ValueError("events must contain at least one event")
+        return value
+
+
+class KpiRequest(BaseModel):
+    kpis: List[str] = Field(default_factory=list)
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+
+
+class RefreshRequest(BaseModel):
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    force_recompute: bool = False

--- a/services/analytics-service/src/services/ingestion.py
+++ b/services/analytics-service/src/services/ingestion.py
@@ -1,0 +1,50 @@
+"""Ingestion service for analytics events."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, Sequence
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .. import schemas
+from ..metrics import observe_ingestion
+from ..models import AnalyticsEvent
+
+
+class IngestionError(Exception):
+    """Raised when an event payload cannot be ingested."""
+
+
+class IngestionService:
+    """Persist analytics events received from APIs or consumers."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def ingest(self, payload: schemas.EventPayload) -> AnalyticsEvent:
+        event = AnalyticsEvent(
+            event_type=payload.event_type,
+            user_id=payload.user_id,
+            occurred_at=payload.occurred_at,
+            ingestion_id=payload.ingestion_id,
+            source=payload.source or "http",
+            payload=payload.payload,
+            context=payload.context,
+        )
+        event.received_at = datetime.now(timezone.utc)
+        latency = (event.received_at - event.occurred_at).total_seconds()
+        try:
+            self._session.add(event)
+            self._session.flush()
+            self._session.commit()
+        except IntegrityError as exc:  # pragma: no cover - defensive branch
+            self._session.rollback()
+            raise IngestionError("Failed to persist event") from exc
+        observe_ingestion(event.event_type, event.source, max(latency, 0.0))
+        return event
+
+    def ingest_batch(self, payloads: Iterable[schemas.EventPayload]) -> Sequence[AnalyticsEvent]:
+        events = [self.ingest(payload) for payload in payloads]
+        self._session.commit()
+        return events

--- a/services/analytics-service/src/services/reporting.py
+++ b/services/analytics-service/src/services/reporting.py
@@ -1,0 +1,58 @@
+"""Reporting service exposing aggregated KPIs."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Dict, List, Sequence
+
+from sqlalchemy.orm import Session
+
+from ..models import KpiSnapshot
+from ..services.warehouse import DEFAULT_KPIS, WarehouseLoader
+
+
+def _normalize_window(start: date | datetime | None, end: date | datetime | None) -> tuple[date, date]:
+    if isinstance(start, datetime):
+        start_date = start.date()
+    else:
+        start_date = start or datetime.utcnow().date()
+    if isinstance(end, datetime):
+        end_date = end.date()
+    else:
+        end_date = end or datetime.utcnow().date()
+    if end_date < start_date:
+        start_date, end_date = end_date, start_date
+    return start_date, end_date
+
+
+class ReportingService:
+    def __init__(self, session: Session):
+        self._session = session
+        self._warehouse = WarehouseLoader(session)
+
+    @property
+    def warehouse(self) -> WarehouseLoader:
+        return self._warehouse
+
+    def list_available_kpis(self) -> Sequence[str]:
+        rows = self._session.query(KpiSnapshot.kpi_name).distinct().order_by(KpiSnapshot.kpi_name.asc()).all()
+        discovered = [row[0] for row in rows]
+        combined = list(dict.fromkeys([*DEFAULT_KPIS, *discovered]))
+        return combined
+
+    def fetch_snapshots(
+        self,
+        names: Sequence[str] | None = None,
+        *,
+        start: date | datetime | None = None,
+        end: date | datetime | None = None,
+    ) -> List[dict[str, object]]:
+        start_date, end_date = _normalize_window(start, end)
+        snapshots = self._warehouse.list_kpis(names, start=start_date, end=end_date)
+        return [snapshot.as_dict() for snapshot in snapshots]
+
+    def refresh(self, *, start: date | datetime | None = None, end: date | datetime | None = None, force: bool = False) -> Dict[str, int]:
+        snapshots = self._warehouse.refresh(start=start, end=end, force=force)
+        return {"rows_materialised": len(snapshots)}
+
+
+__all__ = ["ReportingService"]

--- a/services/analytics-service/src/services/warehouse.py
+++ b/services/analytics-service/src/services/warehouse.py
@@ -1,0 +1,164 @@
+"""Warehouse rollup logic for analytics KPIs."""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Dict, List, Sequence
+from uuid import uuid4
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from ..metrics import observe_rows_materialised, record_warehouse_batch
+from ..models import AnalyticsEvent, KpiSnapshot, WarehouseLoad
+
+DEFAULT_KPIS = ("events.total", "users.daily_active", "funnel.booking_conversion")
+
+
+def _normalize_dates(start: datetime | date | None, end: datetime | date | None) -> tuple[date, date]:
+    today = datetime.now(timezone.utc).date()
+    start_date = (start.date() if isinstance(start, datetime) else start) or today
+    end_date = (end.date() if isinstance(end, datetime) else end) or today
+    if end_date < start_date:
+        start_date, end_date = end_date, start_date
+    return start_date, end_date
+
+
+def _coerce_date(value: object) -> date:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+    raise ValueError(f"Cannot interpret {value!r} as date")
+
+
+class WarehouseLoader:
+    """Materialise aggregates into the warehouse tables."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def refresh(
+        self,
+        start: datetime | date | None = None,
+        end: datetime | date | None = None,
+        *,
+        force: bool = False,
+    ) -> List[KpiSnapshot]:
+        start_date, end_date = _normalize_dates(start, end)
+        lower = datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc)
+        upper = datetime.combine(end_date + timedelta(days=1), datetime.min.time(), tzinfo=timezone.utc)
+
+        batch = WarehouseLoad(batch_id=str(uuid4()), status="running")
+        self._session.add(batch)
+        self._session.flush()
+
+        if force:
+            self._session.query(KpiSnapshot).filter(
+                KpiSnapshot.window_start >= start_date,
+                KpiSnapshot.window_end <= end_date,
+            ).delete(synchronize_session=False)
+
+        with record_warehouse_batch("analytics_kpi_snapshots"):
+            counts_stmt = (
+                select(
+                    func.date(AnalyticsEvent.occurred_at).label("bucket"),
+                    AnalyticsEvent.event_type,
+                    func.count().label("event_count"),
+                )
+                .where(AnalyticsEvent.occurred_at >= lower, AnalyticsEvent.occurred_at < upper)
+                .group_by("bucket", AnalyticsEvent.event_type)
+            )
+            counts_rows = self._session.execute(counts_stmt).all()
+
+            unique_stmt = (
+                select(
+                    func.date(AnalyticsEvent.occurred_at).label("bucket"),
+                    func.count(func.distinct(AnalyticsEvent.user_id)).label("unique_users"),
+                )
+                .where(AnalyticsEvent.occurred_at >= lower, AnalyticsEvent.occurred_at < upper)
+                .group_by("bucket")
+            )
+            unique_rows = self._session.execute(unique_stmt).all()
+            unique_lookup: Dict[date, int] = {
+                _coerce_date(bucket): int(unique or 0) for bucket, unique in unique_rows
+            }
+
+            grouped: Dict[date, Dict[str, int]] = {}
+            for bucket, event_type, count in counts_rows:
+                bucket_date = _coerce_date(bucket)
+                grouped.setdefault(bucket_date, {})[event_type] = int(count or 0)
+
+            snapshots: List[KpiSnapshot] = []
+            for window_start, events_by_type in grouped.items():
+                window_end = window_start
+                total_events = sum(events_by_type.values())
+                unique_users = unique_lookup.get(window_start, 0)
+
+                metadata = {
+                    "events": events_by_type,
+                    "unique_users": unique_users,
+                }
+
+                snapshots.append(
+                    KpiSnapshot(
+                        kpi_name="events.total",
+                        window_start=window_start,
+                        window_end=window_end,
+                        value=float(total_events),
+                        attributes=metadata,
+                    )
+                )
+                snapshots.append(
+                    KpiSnapshot(
+                        kpi_name="users.daily_active",
+                        window_start=window_start,
+                        window_end=window_end,
+                        value=float(unique_users),
+                        attributes=metadata,
+                    )
+                )
+
+                bookings_started = events_by_type.get("booking.started", 0)
+                bookings_completed = events_by_type.get("booking.completed", 0)
+                conversion = (bookings_completed / bookings_started) if bookings_started else 0.0
+                snapshots.append(
+                    KpiSnapshot(
+                        kpi_name="funnel.booking_conversion",
+                        window_start=window_start,
+                        window_end=window_end,
+                        value=float(round(conversion, 4)),
+                        attributes={
+                            "started": bookings_started,
+                            "completed": bookings_completed,
+                        },
+                    )
+                )
+
+            for snapshot in snapshots:
+                self._session.add(snapshot)
+            batch.row_count = len(snapshots)
+            observe_rows_materialised("analytics_kpi_snapshots", batch.row_count)
+
+        batch.status = "succeeded"
+        batch.completed_at = datetime.now(timezone.utc)
+        self._session.flush()
+        self._session.commit()
+        return snapshots
+
+    def list_kpis(
+        self,
+        names: Sequence[str] | None = None,
+        start: date | None = None,
+        end: date | None = None,
+    ) -> List[KpiSnapshot]:
+        start_date, end_date = _normalize_dates(start, end)
+        query = self._session.query(KpiSnapshot).filter(
+            KpiSnapshot.window_start >= start_date,
+            KpiSnapshot.window_end <= end_date,
+        )
+        if names:
+            query = query.filter(KpiSnapshot.kpi_name.in_(names))
+        return list(query.order_by(KpiSnapshot.window_start.asc(), KpiSnapshot.kpi_name.asc()).all())
+
+
+__all__ = ["WarehouseLoader", "DEFAULT_KPIS"]

--- a/services/analytics-service/tests/conftest.py
+++ b/services/analytics-service/tests/conftest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from src.database import dispose_engine, get_session  # type: ignore  # noqa: E402
+from src.main import create_app  # type: ignore  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app({"DATABASE_URL": "sqlite+pysqlite:///:memory:"})
+    app.config.update({"TESTING": True})
+    yield app
+    dispose_engine()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def session(app):
+    with app.app_context():
+        db_session = get_session()
+        yield db_session
+        db_session.close()

--- a/services/analytics-service/tests/test_consumer.py
+++ b/services/analytics-service/tests/test_consumer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.consumers import AnalyticsEventConsumer
+from src.models import AnalyticsEvent
+
+
+def test_consumer_processes_message(session):
+    consumer = AnalyticsEventConsumer(session)
+    message = {
+        "event_type": "booking.started",
+        "occurred_at": datetime.now(timezone.utc).isoformat(),
+        "user_id": "900",
+    }
+    processed = consumer.consume(message)
+    assert processed == 1
+
+    stored = session.query(AnalyticsEvent).count()
+    assert stored == 1
+
+
+def test_consumer_handles_string_payload(session):
+    consumer = AnalyticsEventConsumer(session)
+    message = {
+        "payload": "{\"event_type\": \"booking.completed\", \"occurred_at\": \"%s\"}" % datetime.now(timezone.utc).isoformat()
+    }
+    processed = consumer.consume(message)
+    assert processed == 1
+
+    stored = session.query(AnalyticsEvent).filter_by(event_type="booking.completed").count()
+    assert stored == 1

--- a/services/analytics-service/tests/test_ingestion.py
+++ b/services/analytics-service/tests/test_ingestion.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from datetime import datetime, timezone
+
+from src.models import AnalyticsEvent
+
+
+def test_ingest_single_event(client, session):
+    payload = {
+        "event_type": "booking.started",
+        "user_id": "42",
+        "occurred_at": datetime.now(timezone.utc).isoformat(),
+        "payload": {"plan": "premium"},
+    }
+    response = client.post("/ingest/events", json=payload)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["event_type"] == "booking.started"
+
+    stored = session.query(AnalyticsEvent).all()
+    assert len(stored) == 1
+    assert stored[0].payload["plan"] == "premium"
+
+
+def test_ingest_batch(client, session):
+    now = datetime.now(timezone.utc)
+    events = [
+        {
+            "event_type": "booking.started",
+            "occurred_at": now.isoformat(),
+        },
+        {
+            "event_type": "booking.completed",
+            "occurred_at": now.isoformat(),
+        },
+    ]
+    response = client.post("/ingest/batch", json={"events": events})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ingested"] == 2
+
+    stored = session.query(AnalyticsEvent).count()
+    assert stored >= 2

--- a/services/analytics-service/tests/test_reporting.py
+++ b/services/analytics-service/tests/test_reporting.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+def _seed_events(client):
+    base = datetime.now(timezone.utc)
+    events = []
+    for offset, event_type in enumerate(["booking.started", "booking.completed", "booking.started"]):
+        events.append(
+            {
+                "event_type": event_type,
+                "user_id": str(offset + 1),
+                "occurred_at": (base + timedelta(minutes=offset)).isoformat(),
+            }
+        )
+    client.post("/ingest/batch", json={"events": events})
+
+
+def test_refresh_and_fetch_kpis(client, session):
+    _seed_events(client)
+
+    response = client.post("/reports/refresh", json={})
+    assert response.status_code == 200
+    assert response.get_json()["rows_materialised"] >= 3
+
+    response = client.get("/reports/kpis")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert any(item["kpi_name"] == "events.total" for item in payload["kpis"])
+
+
+def test_refresh_force_recompute(client, session):
+    _seed_events(client)
+    client.post("/reports/refresh", json={})
+    response = client.post("/reports/refresh", json={"force_recompute": True})
+    assert response.status_code == 200
+    assert response.get_json()["rows_materialised"] >= 3

--- a/services/api-gateway/src/app.py
+++ b/services/api-gateway/src/app.py
@@ -551,6 +551,13 @@ def create_app() -> Flask:
     app.config["MESSAGING_SERVICE_STATIC_INSTANCES"] = _get_env(
         "MESSAGING_SERVICE_STATIC_INSTANCES", ""
     ) or ""
+    app.config["ANALYTICS_SERVICE_URL"] = _get_env("ANALYTICS_SERVICE_URL", "") or ""
+    app.config["ANALYTICS_SERVICE_NAME"] = _get_env(
+        "ANALYTICS_SERVICE_NAME", "analytics-service"
+    ) or "analytics-service"
+    app.config["ANALYTICS_SERVICE_STATIC_INSTANCES"] = _get_env(
+        "ANALYTICS_SERVICE_STATIC_INSTANCES", ""
+    ) or ""
     app.config["SERVICE_DISCOVERY_BACKEND"] = _get_env(
         "SERVICE_DISCOVERY_BACKEND", "static"
     ) or "static"
@@ -565,6 +572,7 @@ def create_app() -> Flask:
     app.config["RATE_LIMIT_EVENTS"] = _get_env("RATE_LIMIT_EVENTS", "10/minute") or "10/minute"
     app.config["RATE_LIMIT_MATCHING"] = _get_env("RATE_LIMIT_MATCHING", "10/minute") or "10/minute"
     app.config["RATE_LIMIT_MESSAGING"] = _get_env("RATE_LIMIT_MESSAGING", "10/minute") or "10/minute"
+    app.config["RATE_LIMIT_ANALYTICS"] = _get_env("RATE_LIMIT_ANALYTICS", "10/minute") or "10/minute"
     app.config["API_KEYS"] = api_keys_raw
     app.config["API_KEY_HEADER"] = _get_env("API_KEY_HEADER", "X-API-Key") or "X-API-Key"
     app.config["API_KEY_SALT"] = _get_env("API_KEY_SALT", "") or ""

--- a/services/api-gateway/src/routes/proxy.py
+++ b/services/api-gateway/src/routes/proxy.py
@@ -26,6 +26,7 @@ from ..middleware.resilience import (
 )
 from ..middleware.jwt import require_jwt
 from ..services.registry import (
+    ANALYTICS_SERVICE_CONFIG,
     EVENT_SERVICE_CONFIG,
     MATCHING_SERVICE_CONFIG,
     MESSAGING_SERVICE_CONFIG,
@@ -122,6 +123,18 @@ PROXY_ROUTE_DEFINITIONS: tuple[ProxyRouteDefinition, ...] = (
         summary="Messaging proxy",
         description="Expose messaging endpoints for authenticated users.",
         tags=("Messages",),
+    ),
+    ProxyRouteDefinition(
+        name="analytics",
+        gateway_path="/api/analytics",
+        upstream_prefix="",
+        methods=("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"),
+        upstream_service=ANALYTICS_SERVICE_CONFIG,
+        requires_jwt=True,
+        rate_limit_config="RATE_LIMIT_ANALYTICS",
+        summary="Analytics proxy",
+        description="Expose ingestion, reporting, and metadata APIs for analytics.",
+        tags=("Analytics",),
     ),
 )
 

--- a/services/api-gateway/src/services/registry.py
+++ b/services/api-gateway/src/services/registry.py
@@ -40,12 +40,14 @@ USER_SERVICE_CONFIG = UpstreamServiceConfig("USER_SERVICE", "user-service")
 EVENT_SERVICE_CONFIG = UpstreamServiceConfig("EVENT_SERVICE", "event-service")
 MATCHING_SERVICE_CONFIG = UpstreamServiceConfig("MATCHING_SERVICE", "matching-service")
 MESSAGING_SERVICE_CONFIG = UpstreamServiceConfig("MESSAGING_SERVICE", "messaging-service")
+ANALYTICS_SERVICE_CONFIG = UpstreamServiceConfig("ANALYTICS_SERVICE", "analytics-service")
 
 DEFAULT_UPSTREAM_SERVICES: Tuple[UpstreamServiceConfig, ...] = (
     USER_SERVICE_CONFIG,
     EVENT_SERVICE_CONFIG,
     MATCHING_SERVICE_CONFIG,
     MESSAGING_SERVICE_CONFIG,
+    ANALYTICS_SERVICE_CONFIG,
 )
 
 


### PR DESCRIPTION
## Summary
- add the analytics service with ingestion routes, warehouse rollups, reporting APIs, documentation, and unit tests
- provision an optional Redshift-based analytics warehouse via Terraform and document retention/backfill operations
- wire the analytics service into docker-compose, CI, the API gateway proxy map, and ship a Grafana dashboard for KPIs

## Testing
- pytest -vv (services/analytics-service)


------
https://chatgpt.com/codex/tasks/task_e_68da2d7cbc2c83328bf04844b9f91be5